### PR TITLE
Initial 3D Rubik's cube web app with computer vision

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+dist
+.DS_Store
+*.log
+.vite
+public/wasm
+public/models
+tsconfig.tsbuildinfo

--- a/index.html
+++ b/index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="theme-color" content="#0b0d12" />
+    <title>Rubik 3D · Computer Vision</title>
+    <link rel="icon" href="data:," />
+    <link rel="stylesheet" href="/src/hud/hud.css" />
+  </head>
+  <body>
+    <div id="app">
+      <canvas id="three-canvas"></canvas>
+      <div id="cv-layer">
+        <video id="cv-video" playsinline muted></video>
+        <canvas id="cv-overlay"></canvas>
+      </div>
+      <div id="hud-root"></div>
+      <div id="toast"></div>
+    </div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5431 @@
+{
+  "name": "rubik-cube-3d-cv",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "rubik-cube-3d-cv",
+      "version": "0.1.0",
+      "dependencies": {
+        "@mediapipe/tasks-vision": "^0.10.22",
+        "cubejs": "^1.3.2",
+        "three": "^0.169.0"
+      },
+      "devDependencies": {
+        "@types/three": "^0.169.0",
+        "typescript": "^5.6.2",
+        "vite": "^5.4.10"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@mediapipe/tasks-vision": {
+      "version": "0.10.35",
+      "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.35.tgz",
+      "integrity": "sha512-HOvadwVRE6JC+45nyYhmnywnr5h/J8KZvOeUNVOG9q/0875pZgItznFB9bRTvLc264YSJqiZ1NsIpCStJw/egg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.169.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.169.0.tgz",
+      "integrity": "sha512-oan7qCgJBt03wIaK+4xPWclYRPG9wzcg7Z2f5T8xYTNEF95kh0t0lklxLLYBDo7gQiGLYzE6iF4ta7nXF2bcsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "@webgpu/types": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~0.18.1"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.69",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.69.tgz",
+      "integrity": "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/cubejs": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/cubejs/-/cubejs-1.3.2.tgz",
+      "integrity": "sha512-NuHpWIR/mpjrP3YpU6OaXAbo34idWlzo86GnAqGDG96OHDKyavTAelMyruZ77SgPhQ8l9IcP6/rzXoNcAy9OaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "npm": "^6.0.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
+      "integrity": "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/npm": {
+      "version": "6.14.18",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.18.tgz",
+      "integrity": "sha512-p3SjqSchSuNQUqbJBgwdv0L3O6bKkaSfQrQzJsskNpNKLg0g37c5xTXFV0SqTlX9GWvoGxBELVJMRWq0J8oaLA==",
+      "bundleDependencies": [
+        "abbrev",
+        "ansicolors",
+        "ansistyles",
+        "aproba",
+        "archy",
+        "bin-links",
+        "bluebird",
+        "byte-size",
+        "cacache",
+        "call-limit",
+        "chownr",
+        "ci-info",
+        "cli-columns",
+        "cli-table3",
+        "cmd-shim",
+        "columnify",
+        "config-chain",
+        "debuglog",
+        "detect-indent",
+        "detect-newline",
+        "dezalgo",
+        "editor",
+        "figgy-pudding",
+        "find-npm-prefix",
+        "fs-vacuum",
+        "fs-write-stream-atomic",
+        "gentle-fs",
+        "glob",
+        "graceful-fs",
+        "has-unicode",
+        "hosted-git-info",
+        "iferr",
+        "imurmurhash",
+        "infer-owner",
+        "inflight",
+        "inherits",
+        "ini",
+        "init-package-json",
+        "is-cidr",
+        "json-parse-better-errors",
+        "JSONStream",
+        "lazy-property",
+        "libcipm",
+        "libnpm",
+        "libnpmaccess",
+        "libnpmhook",
+        "libnpmorg",
+        "libnpmsearch",
+        "libnpmteam",
+        "libnpx",
+        "lock-verify",
+        "lockfile",
+        "lodash._baseindexof",
+        "lodash._baseuniq",
+        "lodash._bindcallback",
+        "lodash._cacheindexof",
+        "lodash._createcache",
+        "lodash._getnative",
+        "lodash.clonedeep",
+        "lodash.restparam",
+        "lodash.union",
+        "lodash.uniq",
+        "lodash.without",
+        "lru-cache",
+        "meant",
+        "mississippi",
+        "mkdirp",
+        "move-concurrently",
+        "node-gyp",
+        "nopt",
+        "normalize-package-data",
+        "npm-audit-report",
+        "npm-cache-filename",
+        "npm-install-checks",
+        "npm-lifecycle",
+        "npm-package-arg",
+        "npm-packlist",
+        "npm-pick-manifest",
+        "npm-profile",
+        "npm-registry-fetch",
+        "npm-user-validate",
+        "npmlog",
+        "once",
+        "opener",
+        "osenv",
+        "pacote",
+        "path-is-inside",
+        "promise-inflight",
+        "qrcode-terminal",
+        "query-string",
+        "qw",
+        "read-cmd-shim",
+        "read-installed",
+        "read-package-json",
+        "read-package-tree",
+        "read",
+        "readable-stream",
+        "readdir-scoped-modules",
+        "request",
+        "retry",
+        "rimraf",
+        "safe-buffer",
+        "semver",
+        "sha",
+        "slide",
+        "sorted-object",
+        "sorted-union-stream",
+        "ssri",
+        "stringify-package",
+        "tar",
+        "text-table",
+        "tiny-relative-date",
+        "uid-number",
+        "umask",
+        "unique-filename",
+        "unpipe",
+        "update-notifier",
+        "uuid",
+        "validate-npm-package-license",
+        "validate-npm-package-name",
+        "which",
+        "worker-farm",
+        "write-file-atomic"
+      ],
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "abbrev": "~1.1.1",
+        "ansicolors": "~0.3.2",
+        "ansistyles": "~0.1.3",
+        "aproba": "^2.0.0",
+        "archy": "~1.0.0",
+        "bin-links": "^1.1.8",
+        "bluebird": "^3.7.2",
+        "byte-size": "^5.0.1",
+        "cacache": "^12.0.4",
+        "call-limit": "^1.1.1",
+        "chownr": "^1.1.4",
+        "ci-info": "^2.0.0",
+        "cli-columns": "^3.1.2",
+        "cli-table3": "^0.5.1",
+        "cmd-shim": "^3.0.3",
+        "columnify": "~1.5.4",
+        "config-chain": "^1.1.13",
+        "debuglog": "*",
+        "detect-indent": "~5.0.0",
+        "detect-newline": "^2.1.0",
+        "dezalgo": "^1.0.4",
+        "editor": "~1.0.0",
+        "figgy-pudding": "^3.5.2",
+        "find-npm-prefix": "^1.0.2",
+        "fs-vacuum": "~1.2.10",
+        "fs-write-stream-atomic": "~1.0.10",
+        "gentle-fs": "^2.3.1",
+        "glob": "^7.2.3",
+        "graceful-fs": "^4.2.10",
+        "has-unicode": "~2.0.1",
+        "hosted-git-info": "^2.8.9",
+        "iferr": "^1.0.2",
+        "imurmurhash": "*",
+        "infer-owner": "^1.0.4",
+        "inflight": "~1.0.6",
+        "inherits": "^2.0.4",
+        "ini": "^1.3.8",
+        "init-package-json": "^1.10.3",
+        "is-cidr": "^3.1.1",
+        "json-parse-better-errors": "^1.0.2",
+        "JSONStream": "^1.3.5",
+        "lazy-property": "~1.0.0",
+        "libcipm": "^4.0.8",
+        "libnpm": "^3.0.1",
+        "libnpmaccess": "^3.0.2",
+        "libnpmhook": "^5.0.3",
+        "libnpmorg": "^1.0.1",
+        "libnpmsearch": "^2.0.2",
+        "libnpmteam": "^1.0.2",
+        "libnpx": "^10.2.4",
+        "lock-verify": "^2.2.2",
+        "lockfile": "^1.0.4",
+        "lodash._baseindexof": "*",
+        "lodash._baseuniq": "~4.6.0",
+        "lodash._bindcallback": "*",
+        "lodash._cacheindexof": "*",
+        "lodash._createcache": "*",
+        "lodash._getnative": "*",
+        "lodash.clonedeep": "~4.5.0",
+        "lodash.restparam": "*",
+        "lodash.union": "~4.6.0",
+        "lodash.uniq": "~4.5.0",
+        "lodash.without": "~4.4.0",
+        "lru-cache": "^5.1.1",
+        "meant": "^1.0.3",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.6",
+        "move-concurrently": "^1.0.1",
+        "node-gyp": "^5.1.1",
+        "nopt": "^4.0.3",
+        "normalize-package-data": "^2.5.0",
+        "npm-audit-report": "^1.3.3",
+        "npm-cache-filename": "~1.0.2",
+        "npm-install-checks": "^3.0.2",
+        "npm-lifecycle": "^3.1.5",
+        "npm-package-arg": "^6.1.1",
+        "npm-packlist": "^1.4.8",
+        "npm-pick-manifest": "^3.0.2",
+        "npm-profile": "^4.0.4",
+        "npm-registry-fetch": "^4.0.7",
+        "npm-user-validate": "^1.0.1",
+        "npmlog": "~4.1.2",
+        "once": "~1.4.0",
+        "opener": "^1.5.2",
+        "osenv": "^0.1.5",
+        "pacote": "^9.5.12",
+        "path-is-inside": "~1.0.2",
+        "promise-inflight": "~1.0.1",
+        "qrcode-terminal": "^0.12.0",
+        "query-string": "^6.14.1",
+        "qw": "^1.0.2",
+        "read": "~1.0.7",
+        "read-cmd-shim": "^1.0.5",
+        "read-installed": "~4.0.3",
+        "read-package-json": "^2.1.2",
+        "read-package-tree": "^5.3.1",
+        "readable-stream": "^3.6.0",
+        "readdir-scoped-modules": "^1.1.0",
+        "request": "^2.88.2",
+        "retry": "^0.12.0",
+        "rimraf": "^2.7.1",
+        "safe-buffer": "^5.2.1",
+        "semver": "^5.7.1",
+        "sha": "^3.0.0",
+        "slide": "~1.1.6",
+        "sorted-object": "~2.0.1",
+        "sorted-union-stream": "~2.1.3",
+        "ssri": "^6.0.2",
+        "stringify-package": "^1.0.1",
+        "tar": "^4.4.19",
+        "text-table": "~0.2.0",
+        "tiny-relative-date": "^1.3.0",
+        "uid-number": "0.0.6",
+        "umask": "~1.1.0",
+        "unique-filename": "^1.1.1",
+        "unpipe": "~1.0.0",
+        "update-notifier": "^2.5.0",
+        "uuid": "^3.4.0",
+        "validate-npm-package-license": "^3.0.4",
+        "validate-npm-package-name": "~3.0.0",
+        "which": "^1.3.1",
+        "worker-farm": "^1.7.0",
+        "write-file-atomic": "^2.4.3"
+      },
+      "bin": {
+        "npm": "bin/npm-cli.js",
+        "npx": "bin/npx-cli.js"
+      },
+      "engines": {
+        "node": "6 >=6.2.0 || 8 || >=9.3.0"
+      }
+    },
+    "node_modules/npm/node_modules/@iarna/cli": {
+      "version": "2.1.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.2",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/npm/node_modules/abbrev": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/agent-base": {
+      "version": "4.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "es6-promisify": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/agentkeepalive": {
+      "version": "3.5.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/ansi-align": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^2.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/ansicolors": {
+      "version": "0.3.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/ansistyles": {
+      "version": "0.1.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/aproba": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/archy": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/are-we-there-yet": {
+      "version": "1.1.4",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      }
+    },
+    "node_modules/npm/node_modules/are-we-there-yet/node_modules/readable-stream": {
+      "version": "2.3.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/are-we-there-yet/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/are-we-there-yet/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/are-we-there-yet/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/asap": {
+      "version": "2.0.6",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/asn1": {
+      "version": "0.2.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/assert-plus": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/npm/node_modules/asynckit": {
+      "version": "0.4.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/aws-sign2": {
+      "version": "0.7.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/aws4": {
+      "version": "1.11.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/npm/node_modules/bin-links": {
+      "version": "1.1.8",
+      "inBundle": true,
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "bluebird": "^3.5.3",
+        "cmd-shim": "^3.0.0",
+        "gentle-fs": "^2.3.0",
+        "graceful-fs": "^4.1.15",
+        "npm-normalize-package-bin": "^1.0.0",
+        "write-file-atomic": "^2.3.0"
+      }
+    },
+    "node_modules/npm/node_modules/bluebird": {
+      "version": "3.7.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/boxen": {
+      "version": "1.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-align": "^2.0.0",
+        "camelcase": "^4.0.0",
+        "chalk": "^2.0.1",
+        "cli-boxes": "^1.0.0",
+        "string-width": "^2.0.0",
+        "term-size": "^1.2.0",
+        "widest-line": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/buffer-from": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/builtins": {
+      "version": "1.0.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/byline": {
+      "version": "5.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/byte-size": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/cacache": {
+      "version": "12.0.4",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "bluebird": "^3.5.5",
+        "chownr": "^1.1.1",
+        "figgy-pudding": "^3.5.1",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.1.15",
+        "infer-owner": "^1.0.3",
+        "lru-cache": "^5.1.1",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.3",
+        "ssri": "^6.0.1",
+        "unique-filename": "^1.1.1",
+        "y18n": "^4.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/call-limit": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/camelcase": {
+      "version": "4.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/capture-stack-trace": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/caseless": {
+      "version": "0.12.0",
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/npm/node_modules/chalk": {
+      "version": "2.4.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/chownr": {
+      "version": "1.1.4",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/ci-info": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/cidr-regex": {
+      "version": "2.0.10",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "ip-regex": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/cli-boxes": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/cli-columns": {
+      "version": "3.1.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^2.0.0",
+        "strip-ansi": "^3.0.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/npm/node_modules/cli-table3": {
+      "version": "0.5.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.0",
+        "string-width": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "optionalDependencies": {
+        "colors": "^1.1.2"
+      }
+    },
+    "node_modules/npm/node_modules/cliui": {
+      "version": "5.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/cliui/node_modules/ansi-regex": {
+      "version": "4.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/cliui/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/cliui/node_modules/string-width": {
+      "version": "3.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/cliui/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/clone": {
+      "version": "1.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/npm/node_modules/cmd-shim": {
+      "version": "3.0.3",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "mkdirp": "~0.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/code-point-at": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/color-convert": {
+      "version": "1.9.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.1.1"
+      }
+    },
+    "node_modules/npm/node_modules/color-name": {
+      "version": "1.1.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/colors": {
+      "version": "1.3.3",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/npm/node_modules/columnify": {
+      "version": "1.5.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "strip-ansi": "^3.0.0",
+        "wcwidth": "^1.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/combined-stream": {
+      "version": "1.0.8",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/npm/node_modules/concat-map": {
+      "version": "0.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/concat-stream": {
+      "version": "1.6.2",
+      "engines": [
+        "node >= 0.8"
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/npm/node_modules/concat-stream/node_modules/readable-stream": {
+      "version": "2.3.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/concat-stream/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/concat-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/concat-stream/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/config-chain": {
+      "version": "1.1.13",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
+    "node_modules/npm/node_modules/configstore": {
+      "version": "3.1.5",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dot-prop": "^4.2.1",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^1.0.0",
+        "unique-string": "^1.0.0",
+        "write-file-atomic": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/copy-concurrently": {
+      "version": "1.0.5",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.1.1",
+        "fs-write-stream-atomic": "^1.0.8",
+        "iferr": "^0.1.5",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/copy-concurrently/node_modules/aproba": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/copy-concurrently/node_modules/iferr": {
+      "version": "0.1.5",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/core-util-is": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/create-error-class": {
+      "version": "3.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "capture-stack-trace": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/cross-spawn": {
+      "version": "5.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
+    "node_modules/npm/node_modules/cross-spawn/node_modules/lru-cache": {
+      "version": "4.1.5",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "node_modules/npm/node_modules/cross-spawn/node_modules/yallist": {
+      "version": "2.1.2",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/crypto-random-string": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/cyclist": {
+      "version": "0.2.2",
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/dashdash": {
+      "version": "1.14.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/npm/node_modules/debug": {
+      "version": "3.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/debuglog": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/decamelize": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/decode-uri-component": {
+      "version": "0.2.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/npm/node_modules/deep-extend": {
+      "version": "0.6.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/defaults": {
+      "version": "1.0.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      }
+    },
+    "node_modules/npm/node_modules/define-properties": {
+      "version": "1.1.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-keys": "^1.0.12"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/npm/node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/npm/node_modules/delegates": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/detect-indent": {
+      "version": "5.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/detect-newline": {
+      "version": "2.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/dezalgo": {
+      "version": "1.0.4",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/npm/node_modules/dot-prop": {
+      "version": "4.2.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-obj": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/dotenv": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.6.0"
+      }
+    },
+    "node_modules/npm/node_modules/duplexer3": {
+      "version": "0.1.4",
+      "inBundle": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/npm/node_modules/duplexify": {
+      "version": "3.6.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/duplexify/node_modules/readable-stream": {
+      "version": "2.3.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/duplexify/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/duplexify/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/duplexify/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/ecc-jsbn": {
+      "version": "0.1.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/editor": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/emoji-regex": {
+      "version": "7.0.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/encoding": {
+      "version": "0.1.12",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "~0.4.13"
+      }
+    },
+    "node_modules/npm/node_modules/end-of-stream": {
+      "version": "1.4.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/npm/node_modules/env-paths": {
+      "version": "2.2.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/err-code": {
+      "version": "1.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/errno": {
+      "version": "0.1.7",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "prr": "~1.0.1"
+      },
+      "bin": {
+        "errno": "cli.js"
+      }
+    },
+    "node_modules/npm/node_modules/es-abstract": {
+      "version": "1.12.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/npm/node_modules/es-to-primitive": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/npm/node_modules/es6-promise": {
+      "version": "4.2.8",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/es6-promisify": {
+      "version": "5.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "es6-promise": "^4.0.3"
+      }
+    },
+    "node_modules/npm/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/npm/node_modules/execa": {
+      "version": "0.7.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/execa/node_modules/get-stream": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/extend": {
+      "version": "3.0.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/extsprintf": {
+      "version": "1.3.0",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/figgy-pudding": {
+      "version": "3.5.2",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/filter-obj": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/find-npm-prefix": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/flush-write-stream": {
+      "version": "1.0.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.4"
+      }
+    },
+    "node_modules/npm/node_modules/flush-write-stream/node_modules/readable-stream": {
+      "version": "2.3.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/flush-write-stream/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/flush-write-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/flush-write-stream/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/forever-agent": {
+      "version": "0.6.1",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/form-data": {
+      "version": "2.3.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/npm/node_modules/from2": {
+      "version": "2.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/from2/node_modules/readable-stream": {
+      "version": "2.3.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/from2/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/from2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/from2/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/fs-minipass": {
+      "version": "1.2.7",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^2.6.0"
+      }
+    },
+    "node_modules/npm/node_modules/fs-minipass/node_modules/minipass": {
+      "version": "2.9.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/fs-vacuum": {
+      "version": "1.2.10",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "path-is-inside": "^1.0.1",
+        "rimraf": "^2.5.2"
+      }
+    },
+    "node_modules/npm/node_modules/fs-write-stream-atomic": {
+      "version": "1.0.10",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "iferr": "^0.1.5",
+        "imurmurhash": "^0.1.4",
+        "readable-stream": "1 || 2"
+      }
+    },
+    "node_modules/npm/node_modules/fs-write-stream-atomic/node_modules/iferr": {
+      "version": "0.1.5",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/fs-write-stream-atomic/node_modules/readable-stream": {
+      "version": "2.3.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/fs-write-stream-atomic/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/fs-write-stream-atomic/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/fs-write-stream-atomic/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/function-bind": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/gauge": {
+      "version": "2.7.4",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/gauge/node_modules/aproba": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/gauge/node_modules/string-width": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/genfun": {
+      "version": "5.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/gentle-fs": {
+      "version": "2.3.1",
+      "inBundle": true,
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "aproba": "^1.1.2",
+        "chownr": "^1.1.2",
+        "cmd-shim": "^3.0.3",
+        "fs-vacuum": "^1.2.10",
+        "graceful-fs": "^4.1.11",
+        "iferr": "^0.1.5",
+        "infer-owner": "^1.0.4",
+        "mkdirp": "^0.5.1",
+        "path-is-inside": "^1.0.2",
+        "read-cmd-shim": "^1.0.1",
+        "slide": "^1.1.6"
+      }
+    },
+    "node_modules/npm/node_modules/gentle-fs/node_modules/aproba": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/gentle-fs/node_modules/iferr": {
+      "version": "0.1.5",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/npm/node_modules/get-stream": {
+      "version": "4.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/getpass": {
+      "version": "0.1.7",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/glob": {
+      "version": "7.2.3",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/global-dirs": {
+      "version": "0.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/got": {
+      "version": "6.7.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "create-error-class": "^3.0.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "is-redirect": "^1.0.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "lowercase-keys": "^1.0.0",
+        "safe-buffer": "^5.0.1",
+        "timed-out": "^4.0.0",
+        "unzip-response": "^2.0.1",
+        "url-parse-lax": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/got/node_modules/get-stream": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/graceful-fs": {
+      "version": "4.2.10",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/har-schema": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/har-validator": {
+      "version": "5.1.5",
+      "deprecated": "this library is no longer supported",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/har-validator/node_modules/ajv": {
+      "version": "6.12.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/npm/node_modules/har-validator/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/har-validator/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/has": {
+      "version": "1.0.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/npm/node_modules/has-flag": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/has-symbols": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/npm/node_modules/has-unicode": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/hosted-git-info": {
+      "version": "2.8.9",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/http-cache-semantics": {
+      "version": "3.8.1",
+      "inBundle": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/npm/node_modules/http-proxy-agent": {
+      "version": "2.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "4",
+        "debug": "3.1.0"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/http-signature": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.8",
+        "npm": ">=1.3.7"
+      }
+    },
+    "node_modules/npm/node_modules/https-proxy-agent": {
+      "version": "2.2.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^4.3.0",
+        "debug": "^3.1.0"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/iconv-lite": {
+      "version": "0.4.23",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/iferr": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/ignore-walk": {
+      "version": "3.0.3",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minimatch": "^3.0.4"
+      }
+    },
+    "node_modules/npm/node_modules/import-lazy": {
+      "version": "2.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/npm/node_modules/infer-owner": {
+      "version": "1.0.4",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/inflight": {
+      "version": "1.0.6",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/npm/node_modules/inherits": {
+      "version": "2.0.4",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/ini": {
+      "version": "1.3.8",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/init-package-json": {
+      "version": "1.10.3",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.1",
+        "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
+        "promzard": "^0.3.0",
+        "read": "~1.0.1",
+        "read-package-json": "1 || 2",
+        "semver": "2.x || 3.x || 4 || 5",
+        "validate-npm-package-license": "^3.0.1",
+        "validate-npm-package-name": "^3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/ip": {
+      "version": "1.1.5",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/ip-regex": {
+      "version": "2.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/is-callable": {
+      "version": "1.1.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/npm/node_modules/is-ci": {
+      "version": "1.2.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ci-info": "^1.5.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
+      }
+    },
+    "node_modules/npm/node_modules/is-ci/node_modules/ci-info": {
+      "version": "1.6.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/is-cidr": {
+      "version": "3.1.1",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "cidr-regex": "^2.0.10"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/is-date-object": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/npm/node_modules/is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "number-is-nan": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/is-installed-globally": {
+      "version": "0.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-dirs": "^0.1.0",
+        "is-path-inside": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/is-npm": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/is-obj": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/is-path-inside": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-is-inside": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/is-redirect": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/is-regex": {
+      "version": "1.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "has": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/npm/node_modules/is-retry-allowed": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/is-stream": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/is-symbol": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/npm/node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/isarray": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/isexe": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/isstream": {
+      "version": "0.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/jsbn": {
+      "version": "0.1.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/json-parse-better-errors": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/json-schema": {
+      "version": "0.4.0",
+      "inBundle": true,
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/npm/node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/jsonparse": {
+      "version": "1.3.1",
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/JSONStream": {
+      "version": "1.3.5",
+      "inBundle": true,
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      },
+      "bin": {
+        "JSONStream": "bin.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/jsprim": {
+      "version": "1.4.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.4.0",
+        "verror": "1.10.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/npm/node_modules/latest-version": {
+      "version": "3.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "package-json": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/lazy-property": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/libcipm": {
+      "version": "4.0.8",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "bin-links": "^1.1.2",
+        "bluebird": "^3.5.1",
+        "figgy-pudding": "^3.5.1",
+        "find-npm-prefix": "^1.0.2",
+        "graceful-fs": "^4.1.11",
+        "ini": "^1.3.5",
+        "lock-verify": "^2.1.0",
+        "mkdirp": "^0.5.1",
+        "npm-lifecycle": "^3.0.0",
+        "npm-logical-tree": "^1.2.1",
+        "npm-package-arg": "^6.1.0",
+        "pacote": "^9.1.0",
+        "read-package-json": "^2.0.13",
+        "rimraf": "^2.6.2",
+        "worker-farm": "^1.6.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpm": {
+      "version": "3.0.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "bin-links": "^1.1.2",
+        "bluebird": "^3.5.3",
+        "find-npm-prefix": "^1.0.2",
+        "libnpmaccess": "^3.0.2",
+        "libnpmconfig": "^1.2.1",
+        "libnpmhook": "^5.0.3",
+        "libnpmorg": "^1.0.1",
+        "libnpmpublish": "^1.1.2",
+        "libnpmsearch": "^2.0.2",
+        "libnpmteam": "^1.0.2",
+        "lock-verify": "^2.0.2",
+        "npm-lifecycle": "^3.0.0",
+        "npm-logical-tree": "^1.2.1",
+        "npm-package-arg": "^6.1.0",
+        "npm-profile": "^4.0.2",
+        "npm-registry-fetch": "^4.0.0",
+        "npmlog": "^4.1.2",
+        "pacote": "^9.5.3",
+        "read-package-json": "^2.0.13",
+        "stringify-package": "^1.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmaccess": {
+      "version": "3.0.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "get-stream": "^4.0.0",
+        "npm-package-arg": "^6.1.0",
+        "npm-registry-fetch": "^4.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmconfig": {
+      "version": "1.2.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "figgy-pudding": "^3.5.1",
+        "find-up": "^3.0.0",
+        "ini": "^1.3.5"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmconfig/node_modules/find-up": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmconfig/node_modules/locate-path": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmconfig/node_modules/p-limit": {
+      "version": "2.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmconfig/node_modules/p-locate": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmconfig/node_modules/p-try": {
+      "version": "2.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmhook": {
+      "version": "5.0.3",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "figgy-pudding": "^3.4.1",
+        "get-stream": "^4.0.0",
+        "npm-registry-fetch": "^4.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmorg": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "figgy-pudding": "^3.4.1",
+        "get-stream": "^4.0.0",
+        "npm-registry-fetch": "^4.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmpublish": {
+      "version": "1.1.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "figgy-pudding": "^3.5.1",
+        "get-stream": "^4.0.0",
+        "lodash.clonedeep": "^4.5.0",
+        "normalize-package-data": "^2.4.0",
+        "npm-package-arg": "^6.1.0",
+        "npm-registry-fetch": "^4.0.0",
+        "semver": "^5.5.1",
+        "ssri": "^6.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmsearch": {
+      "version": "2.0.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "figgy-pudding": "^3.5.1",
+        "get-stream": "^4.0.0",
+        "npm-registry-fetch": "^4.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmteam": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "figgy-pudding": "^3.4.1",
+        "get-stream": "^4.0.0",
+        "npm-registry-fetch": "^4.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpx": {
+      "version": "10.2.4",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "dotenv": "^5.0.1",
+        "npm-package-arg": "^6.0.0",
+        "rimraf": "^2.6.2",
+        "safe-buffer": "^5.1.0",
+        "update-notifier": "^2.3.0",
+        "which": "^1.3.0",
+        "y18n": "^4.0.0",
+        "yargs": "^14.2.3"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/lock-verify": {
+      "version": "2.2.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@iarna/cli": "^2.1.0",
+        "npm-package-arg": "^6.1.0",
+        "semver": "^5.4.1"
+      },
+      "bin": {
+        "lock-verify": "cli.js"
+      }
+    },
+    "node_modules/npm/node_modules/lockfile": {
+      "version": "1.0.4",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/npm/node_modules/lodash._baseindexof": {
+      "version": "3.1.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/lodash._baseuniq": {
+      "version": "4.6.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._createset": "~4.0.0",
+        "lodash._root": "~3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/lodash._bindcallback": {
+      "version": "3.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/lodash._cacheindexof": {
+      "version": "3.0.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/lodash._createcache": {
+      "version": "3.1.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._getnative": "^3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/lodash._createset": {
+      "version": "4.0.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/lodash._getnative": {
+      "version": "3.9.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/lodash._root": {
+      "version": "3.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/lodash.restparam": {
+      "version": "3.6.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/lodash.union": {
+      "version": "4.6.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/lodash.uniq": {
+      "version": "4.5.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/lodash.without": {
+      "version": "4.4.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/lowercase-keys": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/npm/node_modules/make-dir": {
+      "version": "1.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/make-fetch-happen": {
+      "version": "5.0.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "agentkeepalive": "^3.4.1",
+        "cacache": "^12.0.0",
+        "http-cache-semantics": "^3.8.1",
+        "http-proxy-agent": "^2.1.0",
+        "https-proxy-agent": "^2.2.3",
+        "lru-cache": "^5.1.1",
+        "mississippi": "^3.0.0",
+        "node-fetch-npm": "^2.0.2",
+        "promise-retry": "^1.1.1",
+        "socks-proxy-agent": "^4.0.0",
+        "ssri": "^6.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/meant": {
+      "version": "1.0.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/mime-db": {
+      "version": "1.35.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/npm/node_modules/mime-types": {
+      "version": "2.1.19",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "~1.35.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/npm/node_modules/minimatch": {
+      "version": "3.1.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/minimist": {
+      "version": "1.2.6",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/minizlib": {
+      "version": "1.3.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^2.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/minizlib/node_modules/minipass": {
+      "version": "2.9.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/mississippi": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "concat-stream": "^1.5.0",
+        "duplexify": "^3.4.2",
+        "end-of-stream": "^1.1.0",
+        "flush-write-stream": "^1.0.0",
+        "from2": "^2.1.0",
+        "parallel-transform": "^1.1.0",
+        "pump": "^3.0.0",
+        "pumpify": "^1.3.3",
+        "stream-each": "^1.1.0",
+        "through2": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/npm/node_modules/move-concurrently": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.1.1",
+        "copy-concurrently": "^1.0.0",
+        "fs-write-stream-atomic": "^1.0.8",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.3"
+      }
+    },
+    "node_modules/npm/node_modules/move-concurrently/node_modules/aproba": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/ms": {
+      "version": "2.1.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/mute-stream": {
+      "version": "0.0.7",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/node-fetch-npm": {
+      "version": "2.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "encoding": "^0.1.11",
+        "json-parse-better-errors": "^1.0.0",
+        "safe-buffer": "^5.1.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp": {
+      "version": "5.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.2",
+        "mkdirp": "^0.5.1",
+        "nopt": "^4.0.1",
+        "npmlog": "^4.1.2",
+        "request": "^2.88.0",
+        "rimraf": "^2.6.3",
+        "semver": "^5.7.1",
+        "tar": "^4.4.12",
+        "which": "^1.3.1"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/nopt": {
+      "version": "4.0.3",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "1",
+        "osenv": "^0.1.4"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      }
+    },
+    "node_modules/npm/node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/normalize-package-data/node_modules/resolve": {
+      "version": "1.10.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "node_modules/npm/node_modules/npm-audit-report": {
+      "version": "1.3.3",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "cli-table3": "^0.5.0",
+        "console-control-strings": "^1.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-bundled": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/npm-cache-filename": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/npm-install-checks": {
+      "version": "3.0.2",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "semver": "^2.3.0 || 3.x || 4 || 5"
+      }
+    },
+    "node_modules/npm/node_modules/npm-lifecycle": {
+      "version": "3.1.5",
+      "inBundle": true,
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "byline": "^5.0.0",
+        "graceful-fs": "^4.1.15",
+        "node-gyp": "^5.0.2",
+        "resolve-from": "^4.0.0",
+        "slide": "^1.1.6",
+        "uid-number": "0.0.6",
+        "umask": "^1.1.0",
+        "which": "^1.3.1"
+      }
+    },
+    "node_modules/npm/node_modules/npm-logical-tree": {
+      "version": "1.2.1",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/npm-normalize-package-bin": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/npm-package-arg": {
+      "version": "6.1.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "hosted-git-info": "^2.7.1",
+        "osenv": "^0.1.5",
+        "semver": "^5.6.0",
+        "validate-npm-package-name": "^3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-packlist": {
+      "version": "1.4.8",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "ignore-walk": "^3.0.1",
+        "npm-bundled": "^1.0.1",
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/npm-pick-manifest": {
+      "version": "3.0.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "figgy-pudding": "^3.5.1",
+        "npm-package-arg": "^6.0.0",
+        "semver": "^5.4.1"
+      }
+    },
+    "node_modules/npm/node_modules/npm-profile": {
+      "version": "4.0.4",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.1.2 || 2",
+        "figgy-pudding": "^3.4.1",
+        "npm-registry-fetch": "^4.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-registry-fetch": {
+      "version": "4.0.7",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "bluebird": "^3.5.1",
+        "figgy-pudding": "^3.4.1",
+        "JSONStream": "^1.3.4",
+        "lru-cache": "^5.1.1",
+        "make-fetch-happen": "^5.0.0",
+        "npm-package-arg": "^6.1.0",
+        "safe-buffer": "^5.2.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-registry-fetch/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/npm-run-path": {
+      "version": "2.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/npm-user-validate": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/npm/node_modules/npmlog": {
+      "version": "4.1.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/number-is-nan": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/oauth-sign": {
+      "version": "0.9.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/object-assign": {
+      "version": "4.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/object-keys": {
+      "version": "1.0.12",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/npm/node_modules/object.getownpropertydescriptors": {
+      "version": "2.0.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/npm/node_modules/once": {
+      "version": "1.4.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/npm/node_modules/opener": {
+      "version": "1.5.2",
+      "inBundle": true,
+      "license": "(WTFPL OR MIT)",
+      "bin": {
+        "opener": "bin/opener-bin.js"
+      }
+    },
+    "node_modules/npm/node_modules/os-homedir": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/osenv": {
+      "version": "0.1.5",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/p-finally": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/package-json": {
+      "version": "4.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "got": "^6.7.1",
+        "registry-auth-token": "^3.0.1",
+        "registry-url": "^3.0.3",
+        "semver": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/pacote": {
+      "version": "9.5.12",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "bluebird": "^3.5.3",
+        "cacache": "^12.0.2",
+        "chownr": "^1.1.2",
+        "figgy-pudding": "^3.5.1",
+        "get-stream": "^4.1.0",
+        "glob": "^7.1.3",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^5.1.1",
+        "make-fetch-happen": "^5.0.0",
+        "minimatch": "^3.0.4",
+        "minipass": "^2.3.5",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "normalize-package-data": "^2.4.0",
+        "npm-normalize-package-bin": "^1.0.0",
+        "npm-package-arg": "^6.1.0",
+        "npm-packlist": "^1.1.12",
+        "npm-pick-manifest": "^3.0.0",
+        "npm-registry-fetch": "^4.0.0",
+        "osenv": "^0.1.5",
+        "promise-inflight": "^1.0.1",
+        "promise-retry": "^1.1.1",
+        "protoduck": "^5.0.1",
+        "rimraf": "^2.6.2",
+        "safe-buffer": "^5.1.2",
+        "semver": "^5.6.0",
+        "ssri": "^6.0.1",
+        "tar": "^4.4.10",
+        "unique-filename": "^1.1.1",
+        "which": "^1.3.1"
+      }
+    },
+    "node_modules/npm/node_modules/pacote/node_modules/minipass": {
+      "version": "2.9.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/parallel-transform": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "cyclist": "~0.2.2",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.1.5"
+      }
+    },
+    "node_modules/npm/node_modules/parallel-transform/node_modules/readable-stream": {
+      "version": "2.3.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/parallel-transform/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/parallel-transform/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/parallel-transform/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/path-exists": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/path-is-inside": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "(WTFPL OR MIT)"
+    },
+    "node_modules/npm/node_modules/path-key": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/path-parse": {
+      "version": "1.0.7",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/performance-now": {
+      "version": "2.1.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/pify": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/prepend-http": {
+      "version": "1.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/process-nextick-args": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/promise-inflight": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/promise-retry": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "err-code": "^1.0.0",
+        "retry": "^0.10.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/npm/node_modules/promise-retry/node_modules/retry": {
+      "version": "0.10.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/promzard": {
+      "version": "0.3.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "read": "1"
+      }
+    },
+    "node_modules/npm/node_modules/proto-list": {
+      "version": "1.2.4",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/protoduck": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "genfun": "^5.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/prr": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/pseudomap": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/psl": {
+      "version": "1.9.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/pump": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/npm/node_modules/pumpify": {
+      "version": "1.5.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexify": "^3.6.0",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/pumpify/node_modules/pump": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/npm/node_modules/qrcode-terminal": {
+      "version": "0.12.0",
+      "inBundle": true,
+      "bin": {
+        "qrcode-terminal": "bin/qrcode-terminal.js"
+      }
+    },
+    "node_modules/npm/node_modules/qs": {
+      "version": "6.5.3",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/npm/node_modules/query-string": {
+      "version": "6.14.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "decode-uri-component": "^0.2.0",
+        "filter-obj": "^1.1.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm/node_modules/qw": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/rc": {
+      "version": "1.2.8",
+      "inBundle": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/npm/node_modules/read": {
+      "version": "1.0.7",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "mute-stream": "~0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/npm/node_modules/read-cmd-shim": {
+      "version": "1.0.5",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.2"
+      }
+    },
+    "node_modules/npm/node_modules/read-installed": {
+      "version": "4.0.3",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "debuglog": "^1.0.1",
+        "read-package-json": "^2.0.0",
+        "readdir-scoped-modules": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "slide": "~1.1.3",
+        "util-extend": "^1.0.1"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.2"
+      }
+    },
+    "node_modules/npm/node_modules/read-package-json": {
+      "version": "2.1.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "normalize-package-data": "^2.0.0",
+        "npm-normalize-package-bin": "^1.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/read-package-tree": {
+      "version": "5.3.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "read-package-json": "^2.0.0",
+        "readdir-scoped-modules": "^1.0.0",
+        "util-promisify": "^2.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/npm/node_modules/readdir-scoped-modules": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "debuglog": "^1.0.1",
+        "dezalgo": "^1.0.0",
+        "graceful-fs": "^4.1.2",
+        "once": "^1.3.0"
+      }
+    },
+    "node_modules/npm/node_modules/registry-auth-token": {
+      "version": "3.4.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "rc": "^1.1.6",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/registry-url": {
+      "version": "3.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "rc": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/request": {
+      "version": "2.88.2",
+      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/npm/node_modules/require-directory": {
+      "version": "2.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/retry": {
+      "version": "0.12.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/npm/node_modules/rimraf": {
+      "version": "2.7.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/npm/node_modules/run-queue": {
+      "version": "1.0.3",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.1.1"
+      }
+    },
+    "node_modules/npm/node_modules/run-queue/node_modules/aproba": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/semver": {
+      "version": "5.7.1",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/npm/node_modules/semver-diff": {
+      "version": "2.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^5.0.3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/set-blocking": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/sha": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "(BSD-2-Clause OR MIT)",
+      "dependencies": {
+        "graceful-fs": "^4.1.2"
+      }
+    },
+    "node_modules/npm/node_modules/shebang-command": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/signal-exit": {
+      "version": "3.0.2",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/slide": {
+      "version": "1.1.6",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/smart-buffer": {
+      "version": "4.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/socks": {
+      "version": "2.3.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip": "1.1.5",
+        "smart-buffer": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/socks-proxy-agent": {
+      "version": "4.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "~4.2.1",
+        "socks": "~2.3.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/npm/node_modules/socks-proxy-agent/node_modules/agent-base": {
+      "version": "4.2.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "es6-promisify": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/sorted-object": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "(WTFPL OR MIT)"
+    },
+    "node_modules/npm/node_modules/sorted-union-stream": {
+      "version": "2.1.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "from2": "^1.3.0",
+        "stream-iterate": "^1.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/sorted-union-stream/node_modules/from2": {
+      "version": "1.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "readable-stream": "~1.1.10"
+      }
+    },
+    "node_modules/npm/node_modules/sorted-union-stream/node_modules/isarray": {
+      "version": "0.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/sorted-union-stream/node_modules/readable-stream": {
+      "version": "1.1.14",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/npm/node_modules/sorted-union-stream/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/spdx-correct": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/spdx-exceptions": {
+      "version": "2.1.0",
+      "inBundle": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/npm/node_modules/spdx-expression-parse": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/spdx-license-ids": {
+      "version": "3.0.5",
+      "inBundle": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/npm/node_modules/split-on-first": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/sshpk": {
+      "version": "1.17.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/ssri": {
+      "version": "6.0.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "figgy-pudding": "^3.5.1"
+      }
+    },
+    "node_modules/npm/node_modules/stream-each": {
+      "version": "1.2.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/stream-iterate": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.1.5",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/stream-iterate/node_modules/readable-stream": {
+      "version": "2.3.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/stream-iterate/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/stream-iterate/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/stream-iterate/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/stream-shift": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/strict-uri-encode": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/npm/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.2.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/string-width": {
+      "version": "2.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/string-width/node_modules/ansi-regex": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/string-width/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/string-width/node_modules/strip-ansi": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/stringify-package": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/strip-eof": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/supports-color": {
+      "version": "5.4.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/tar": {
+      "version": "4.4.19",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^1.1.4",
+        "fs-minipass": "^1.2.7",
+        "minipass": "^2.9.0",
+        "minizlib": "^1.3.3",
+        "mkdirp": "^0.5.5",
+        "safe-buffer": "^5.2.1",
+        "yallist": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=4.5"
+      }
+    },
+    "node_modules/npm/node_modules/tar/node_modules/minipass": {
+      "version": "2.9.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/tar/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/tar/node_modules/yallist": {
+      "version": "3.1.1",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/term-size": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/text-table": {
+      "version": "0.2.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/through": {
+      "version": "2.3.8",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/through2": {
+      "version": "2.0.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/through2/node_modules/readable-stream": {
+      "version": "2.3.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/through2/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/through2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/through2/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/timed-out": {
+      "version": "4.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/tiny-relative-date": {
+      "version": "1.3.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/tough-cookie": {
+      "version": "2.5.0",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/npm/node_modules/tough-cookie/node_modules/punycode": {
+      "version": "2.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "inBundle": true,
+      "license": "Unlicense"
+    },
+    "node_modules/npm/node_modules/typedarray": {
+      "version": "0.0.6",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/uid-number": {
+      "version": "0.0.6",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/umask": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/unique-filename": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "unique-slug": "^2.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/unique-slug": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      }
+    },
+    "node_modules/npm/node_modules/unique-string": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "crypto-random-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/unpipe": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/npm/node_modules/unzip-response": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/update-notifier": {
+      "version": "2.5.0",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boxen": "^1.2.1",
+        "chalk": "^2.0.1",
+        "configstore": "^3.0.0",
+        "import-lazy": "^2.1.0",
+        "is-ci": "^1.0.10",
+        "is-installed-globally": "^0.1.0",
+        "is-npm": "^1.0.0",
+        "latest-version": "^3.0.0",
+        "semver-diff": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/uri-js": {
+      "version": "4.4.1",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/uri-js/node_modules/punycode": {
+      "version": "2.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/url-parse-lax": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "prepend-http": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/util-extend": {
+      "version": "1.0.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/util-promisify": {
+      "version": "2.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "object.getownpropertydescriptors": "^2.0.3"
+      }
+    },
+    "node_modules/npm/node_modules/uuid": {
+      "version": "3.4.0",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/npm/node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/validate-npm-package-name": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "builtins": "^1.0.3"
+      }
+    },
+    "node_modules/npm/node_modules/verror": {
+      "version": "1.10.0",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "node_modules/npm/node_modules/wcwidth": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/npm/node_modules/which": {
+      "version": "1.3.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/npm/node_modules/which-module": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/wide-align": {
+      "version": "1.1.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^1.0.2"
+      }
+    },
+    "node_modules/npm/node_modules/wide-align/node_modules/string-width": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/widest-line": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/worker-farm": {
+      "version": "1.7.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "errno": "~0.1.7"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi": {
+      "version": "5.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "4.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "3.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/wrappy": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/write-file-atomic": {
+      "version": "2.4.3",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/npm/node_modules/xdg-basedir": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/xtend": {
+      "version": "4.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/npm/node_modules/y18n": {
+      "version": "4.0.1",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/yallist": {
+      "version": "3.0.3",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/yargs": {
+      "version": "14.2.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^5.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^15.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/yargs-parser": {
+      "version": "15.0.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "node_modules/npm/node_modules/yargs-parser/node_modules/camelcase": {
+      "version": "5.3.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/yargs/node_modules/ansi-regex": {
+      "version": "4.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/yargs/node_modules/find-up": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/yargs/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/yargs/node_modules/locate-path": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/yargs/node_modules/p-limit": {
+      "version": "2.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm/node_modules/yargs/node_modules/p-locate": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/yargs/node_modules/p-try": {
+      "version": "2.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/yargs/node_modules/string-width": {
+      "version": "3.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/yargs/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/three": {
+      "version": "0.169.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.169.0.tgz",
+      "integrity": "sha512-Ed906MA3dR4TS5riErd4QBsRGPcx+HBDX2O5yYE5GqJeFQTPU+M56Va/f/Oph9X7uZo3W3o4l2ZhBZ6f6qUv0w==",
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "rubik-cube-3d-cv",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "prebuild": "node scripts/copy-mediapipe-assets.mjs",
+    "predev": "node scripts/copy-mediapipe-assets.mjs",
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@mediapipe/tasks-vision": "^0.10.22",
+    "cubejs": "^1.3.2",
+    "three": "^0.169.0"
+  },
+  "devDependencies": {
+    "@types/three": "^0.169.0",
+    "typescript": "^5.6.2",
+    "vite": "^5.4.10"
+  }
+}

--- a/scripts/copy-mediapipe-assets.mjs
+++ b/scripts/copy-mediapipe-assets.mjs
@@ -1,0 +1,86 @@
+import { mkdir, copyFile, readdir, access } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import https from 'node:https';
+import { createWriteStream } from 'node:fs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+
+const wasmSrc = resolve(root, 'node_modules/@mediapipe/tasks-vision/wasm');
+const wasmDst = resolve(root, 'public/wasm');
+const modelsDir = resolve(root, 'public/models');
+const handModelPath = join(modelsDir, 'hand_landmarker.task');
+const handModelUrl =
+  'https://storage.googleapis.com/mediapipe-models/hand_landmarker/hand_landmarker/float16/latest/hand_landmarker.task';
+
+async function exists(p) {
+  try {
+    await access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function copyDir(src, dst) {
+  await mkdir(dst, { recursive: true });
+  const entries = await readdir(src, { withFileTypes: true });
+  for (const entry of entries) {
+    const srcPath = join(src, entry.name);
+    const dstPath = join(dst, entry.name);
+    if (entry.isDirectory()) {
+      await copyDir(srcPath, dstPath);
+    } else {
+      await copyFile(srcPath, dstPath);
+    }
+  }
+}
+
+function download(url, dst) {
+  return new Promise((resolveP, rejectP) => {
+    const file = createWriteStream(dst);
+    https
+      .get(url, (res) => {
+        if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+          file.close();
+          download(res.headers.location, dst).then(resolveP, rejectP);
+          return;
+        }
+        if (res.statusCode !== 200) {
+          file.close();
+          rejectP(new Error(`HTTP ${res.statusCode} for ${url}`));
+          return;
+        }
+        res.pipe(file);
+        file.on('finish', () => file.close(() => resolveP()));
+      })
+      .on('error', rejectP);
+  });
+}
+
+async function main() {
+  if (await exists(wasmSrc)) {
+    await copyDir(wasmSrc, wasmDst);
+    console.log(`[mediapipe] copied wasm -> ${wasmDst}`);
+  } else {
+    console.warn(`[mediapipe] wasm not found at ${wasmSrc}; run "npm install" first.`);
+  }
+
+  await mkdir(modelsDir, { recursive: true });
+  if (!(await exists(handModelPath))) {
+    console.log('[mediapipe] downloading hand_landmarker.task ...');
+    try {
+      await download(handModelUrl, handModelPath);
+      console.log(`[mediapipe] saved -> ${handModelPath}`);
+    } catch (err) {
+      console.warn(`[mediapipe] could not download model: ${err.message}`);
+      console.warn('[mediapipe] you can drop the file manually at public/models/hand_landmarker.task');
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/App.ts
+++ b/src/app/App.ts
@@ -1,0 +1,245 @@
+import * as THREE from 'three';
+import { Renderer } from '../render/Renderer';
+import { createCamera, createScene } from '../render/Scene';
+import { createOrbit } from '../render/OrbitCam';
+import { CubeView } from '../cube/CubeView';
+import { CubeModel } from '../cube/CubeModel';
+import { MoveEngine } from '../cube/MoveEngine';
+import { generateScramble } from '../cube/Scrambler';
+import { Solver } from '../solver/Solver';
+import { Hud } from '../hud/Hud';
+import { Webcam } from '../cv/Webcam';
+import { HandTracker } from '../cv/HandTracker';
+import { GestureClassifier } from '../cv/gestures/GestureClassifier';
+import { GestureMapper } from '../cv/gestures/GestureMapper';
+import { GridOverlay } from '../cv/scan/GridOverlay';
+import { ScanController } from '../cv/scan/ScanController';
+import { bus } from './events';
+import type { Mode, Move } from '../types';
+import { expandHalfTurns } from '../cube/Notation';
+
+export class App {
+  private renderer: Renderer;
+  private scene: THREE.Scene;
+  private camera: THREE.PerspectiveCamera;
+  private orbit: ReturnType<typeof createOrbit>;
+  private view: CubeView;
+  private model: CubeModel;
+  private engine: MoveEngine;
+  private solver: Solver;
+  private hud: Hud;
+
+  private webcam: Webcam;
+  private handTracker: HandTracker;
+  private gestureClassifier: GestureClassifier;
+  private gestureMapper: GestureMapper;
+  private gridOverlay: GridOverlay;
+  private scanCtl: ScanController;
+
+  private mode: Mode = 'mouse';
+  private cvFrame = 0;
+  private pivot: THREE.Group;
+
+  constructor() {
+    const canvas = document.getElementById('three-canvas') as HTMLCanvasElement;
+    this.renderer = new Renderer(canvas);
+    this.scene = createScene();
+    this.camera = createCamera(this.renderer.aspect);
+    this.orbit = createOrbit(this.camera, canvas);
+
+    this.view = new CubeView();
+    this.scene.add(this.view.group);
+    this.pivot = new THREE.Group();
+    this.view.group.add(this.pivot);
+
+    this.model = new CubeModel();
+    this.engine = new MoveEngine(this.view, this.model, this.pivot);
+
+    this.solver = new Solver();
+
+    const hudRoot = document.getElementById('hud-root')!;
+    this.hud = new Hud(hudRoot, {
+      onScramble: () => this.scramble(),
+      onReset: () => this.reset(),
+      onSolve: () => this.solve(),
+      onModeChange: (m) => this.setMode(m),
+      onCameraToggle: () => this.toggleCamera(),
+      onScanCapture: () => this.scanCtl.capture(),
+      onScanRestart: () => this.scanCtl.start(),
+    });
+    this.hud.setMode('mouse');
+
+    const video = document.getElementById('cv-video') as HTMLVideoElement;
+    const overlay = document.getElementById('cv-overlay') as HTMLCanvasElement;
+    this.webcam = new Webcam(video);
+    this.handTracker = new HandTracker();
+    this.gestureClassifier = new GestureClassifier();
+    this.gestureMapper = new GestureMapper({
+      onMove: (m) => this.engine.queueMove(m),
+    });
+    this.gridOverlay = new GridOverlay(overlay);
+    this.scanCtl = new ScanController(this.webcam, this.gridOverlay, (res) => this.applyScanResult(res));
+
+    this.bindKeys();
+    this.bindBus();
+
+    window.addEventListener('resize', () => {
+      this.camera.aspect = this.renderer.aspect;
+      this.camera.updateProjectionMatrix();
+    });
+  }
+
+  start(): void {
+    this.loop();
+  }
+
+  private loop = (): void => {
+    requestAnimationFrame(this.loop);
+    this.orbit.update();
+
+    if (this.mode === 'gestures' && this.webcam.isOn() && this.handTracker.isReady()) {
+      this.cvFrame += 1;
+      // Throttle hand detection to ~30 Hz on 60 fps render.
+      if (this.cvFrame % 2 === 0) {
+        const result = this.handTracker.detect(this.webcam.video, performance.now());
+        if (result) {
+          const frame = this.gestureClassifier.classify(result, performance.now());
+          this.gestureMapper.process(frame);
+        }
+      }
+    }
+
+    this.renderer.render(this.scene, this.camera);
+  };
+
+  private bindKeys(): void {
+    const map: Record<string, Move> = {
+      r: 'R', R: "R'",
+      u: 'U', U: "U'",
+      f: 'F', F: "F'",
+      l: 'L', L: "L'",
+      d: 'D', D: "D'",
+      b: 'B', B: "B'",
+    };
+    window.addEventListener('keydown', (e) => {
+      if (e.target && (e.target as HTMLElement).tagName === 'INPUT') return;
+      if (e.code === 'Space') {
+        if (this.mode === 'scan') {
+          e.preventDefault();
+          this.scanCtl.capture();
+        }
+        return;
+      }
+      const move = map[e.key];
+      if (move) {
+        this.engine.queueMove(move);
+      }
+    });
+  }
+
+  private bindBus(): void {
+    bus.on('scan:progress', ({ faceIndex, total }) => {
+      const label = this.scanCtl.faceLabel();
+      this.hud.setScanProgress(faceIndex, total, `Mostrando: <b>${label}</b>. Pulsa <kbd>Espacio</kbd> o el botón.`);
+    });
+  }
+
+  private async scramble(): Promise<void> {
+    const moves = generateScramble(22);
+    bus.emit('cube:scrambled', { moves });
+    this.engine.resetCounter();
+    for (const m of moves) {
+      this.engine.setSilent();
+      await this.engine.queueMove(m);
+    }
+  }
+
+  private reset(): void {
+    this.model.reset();
+    this.view.repaintFromFacelets(this.model.getFacelets());
+    this.engine.resetCounter();
+    bus.emit('cube:reset', undefined);
+  }
+
+  private async solve(): Promise<void> {
+    if (!this.solver.isReady()) {
+      bus.emit('toast', { message: 'Solver cargando, espera unos segundos…', kind: 'warn' });
+      return;
+    }
+    if (this.model.isSolved()) {
+      bus.emit('toast', { message: 'Ya está resuelto', kind: 'info' });
+      return;
+    }
+    try {
+      const facelets = this.model.getFacelets();
+      const moves = await this.solver.solve(facelets);
+      const expanded = expandHalfTurns(moves as Move[]);
+      for (const m of expanded) {
+        await this.engine.queueMove(m);
+      }
+    } catch (err) {
+      bus.emit('toast', { message: `Error al resolver: ${(err as Error).message}`, kind: 'error' });
+    }
+  }
+
+  private async setMode(mode: Mode): Promise<void> {
+    if (this.mode === mode) return;
+    this.mode = mode;
+    this.hud.setMode(mode);
+    const cvLayer = document.getElementById('cv-layer')!;
+    cvLayer.classList.toggle('active', mode !== 'mouse');
+    cvLayer.classList.toggle('scan-mode', mode === 'scan');
+    bus.emit('mode:changed', { mode });
+
+    if (mode === 'mouse') {
+      this.gridOverlay.clear();
+      return;
+    }
+
+    if (!this.webcam.isOn()) {
+      try {
+        await this.webcam.start();
+      } catch {
+        return;
+      }
+    }
+
+    if (mode === 'gestures') {
+      try {
+        await this.handTracker.init();
+      } catch {
+        /* error already toasted */
+      }
+    } else if (mode === 'scan') {
+      this.scanCtl.start();
+    }
+  }
+
+  private async toggleCamera(): Promise<void> {
+    if (this.webcam.isOn()) {
+      this.webcam.stop();
+      this.gridOverlay.clear();
+      const cvLayer = document.getElementById('cv-layer')!;
+      cvLayer.classList.remove('active');
+    } else {
+      try {
+        await this.webcam.start();
+        document.getElementById('cv-layer')!.classList.add('active');
+      } catch {
+        /* error already toasted */
+      }
+    }
+  }
+
+  private applyScanResult(res: { stickers54: import('../types').StickerColor[] }): void {
+    try {
+      this.model.setFromStickers(res.stickers54);
+      this.view.repaintFromFacelets(this.model.getFacelets());
+      // re-attach pivot (was inside view.group; group rebuilt? No — repaint reuses cubies)
+      bus.emit('toast', { message: 'Escaneo completado, listo para resolver', kind: 'info' });
+      this.setMode('mouse');
+    } catch (err) {
+      bus.emit('toast', { message: `Estado inválido: ${(err as Error).message}`, kind: 'error' });
+    }
+  }
+}

--- a/src/app/events.ts
+++ b/src/app/events.ts
@@ -1,0 +1,43 @@
+import type { Move, Mode } from '../types';
+
+export interface AppEvents {
+  'move:applied': { move: Move; total: number };
+  'cube:solved': void;
+  'cube:reset': void;
+  'cube:scrambled': { moves: Move[] };
+  'solver:ready': void;
+  'solver:solving': void;
+  'solver:solution': { moves: Move[] };
+  'solver:error': { message: string };
+  'cv:error': { message: string };
+  'cv:camera-on': void;
+  'cv:camera-off': void;
+  'mode:changed': { mode: Mode };
+  'scan:progress': { faceIndex: number; total: number };
+  'scan:complete': void;
+  'toast': { message: string; kind?: 'info' | 'warn' | 'error' };
+}
+
+type Handler<E extends keyof AppEvents> = (payload: AppEvents[E]) => void;
+
+export class EventBus {
+  private listeners = new Map<keyof AppEvents, Set<Handler<keyof AppEvents>>>();
+
+  on<E extends keyof AppEvents>(event: E, fn: Handler<E>): () => void {
+    let set = this.listeners.get(event);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(event, set);
+    }
+    set.add(fn as Handler<keyof AppEvents>);
+    return () => set!.delete(fn as Handler<keyof AppEvents>);
+  }
+
+  emit<E extends keyof AppEvents>(event: E, payload: AppEvents[E]): void {
+    const set = this.listeners.get(event);
+    if (!set) return;
+    for (const fn of set) (fn as Handler<E>)(payload);
+  }
+}
+
+export const bus = new EventBus();

--- a/src/cube/CubeModel.ts
+++ b/src/cube/CubeModel.ts
@@ -1,0 +1,84 @@
+import Cube from 'cubejs';
+import type { Move, StickerColor } from '../types';
+import { FACE_COLOR } from '../types';
+import { expandHalfTurns } from './Notation';
+
+const FACE_LETTER_TO_COLOR: Record<string, StickerColor> = {
+  U: FACE_COLOR.U,
+  R: FACE_COLOR.R,
+  F: FACE_COLOR.F,
+  D: FACE_COLOR.D,
+  L: FACE_COLOR.L,
+  B: FACE_COLOR.B,
+};
+
+const COLOR_TO_FACE_LETTER: Record<StickerColor, string> = {
+  W: 'U',
+  R: 'R',
+  G: 'F',
+  Y: 'D',
+  O: 'L',
+  B: 'B',
+};
+
+export class CubeModel {
+  private cube: Cube;
+
+  constructor() {
+    this.cube = new Cube();
+  }
+
+  applyMove(move: Move): void {
+    this.cube.move(move);
+  }
+
+  applySequence(moves: Move[]): void {
+    if (moves.length === 0) return;
+    this.cube.move(moves.join(' '));
+  }
+
+  /** Returns the cube's facelet string (54 chars in URFDLB order). */
+  getFacelets(): string {
+    return this.cube.asString();
+  }
+
+  /** Returns the array of 54 sticker colors in URFDLB order. */
+  getStickers(): StickerColor[] {
+    const facelets = this.getFacelets();
+    const out: StickerColor[] = new Array(54);
+    for (let i = 0; i < 54; i++) {
+      out[i] = FACE_LETTER_TO_COLOR[facelets[i]];
+    }
+    return out;
+  }
+
+  setFromFacelets(facelets: string): void {
+    if (facelets.length !== 54) {
+      throw new Error(`Facelet string must be 54 chars, got ${facelets.length}`);
+    }
+    this.cube = Cube.fromString(facelets);
+  }
+
+  setFromStickers(colors: StickerColor[]): void {
+    if (colors.length !== 54) throw new Error('Need exactly 54 colors');
+    const s = colors.map((c) => COLOR_TO_FACE_LETTER[c]).join('');
+    this.setFromFacelets(s);
+  }
+
+  isSolved(): boolean {
+    return this.cube.isSolved();
+  }
+
+  reset(): void {
+    this.cube = new Cube();
+  }
+
+  clone(): CubeModel {
+    const m = new CubeModel();
+    m.cube = this.cube.clone();
+    return m;
+  }
+
+  /** For solver IO: expand R2-style halves to atomic quarter pairs if needed. */
+  static expandHalfTurns = expandHalfTurns;
+}

--- a/src/cube/CubeView.ts
+++ b/src/cube/CubeView.ts
@@ -1,0 +1,164 @@
+import * as THREE from 'three';
+import type { Face, StickerColor } from '../types';
+import { COLOR_HEX, FACES } from '../types';
+import { FACELET_MAP, faceletGlobalIndex, type Vec3 } from './FaceletMap';
+
+export interface Cubie {
+  mesh: THREE.Group;
+  /** Permanent home position on the lattice. Used to re-skin from a facelet string. */
+  home: Vec3;
+  /** Stickers indexed by their original outward direction. */
+  stickers: Map<Face, THREE.Mesh>;
+}
+
+const CUBIE_SIZE = 0.96;
+const STICKER_SIZE = 0.86;
+const STICKER_INSET = 0.501;
+
+const FACE_NORMAL: Record<Face, Vec3> = {
+  U: [0, 1, 0],
+  R: [1, 0, 0],
+  F: [0, 0, 1],
+  D: [0, -1, 0],
+  L: [-1, 0, 0],
+  B: [0, 0, -1],
+};
+
+function makeCubieBody(): THREE.Mesh {
+  const geo = new THREE.BoxGeometry(CUBIE_SIZE, CUBIE_SIZE, CUBIE_SIZE);
+  const mat = new THREE.MeshStandardMaterial({
+    color: 0x111418,
+    roughness: 0.6,
+    metalness: 0.05,
+  });
+  return new THREE.Mesh(geo, mat);
+}
+
+function makeStickerMesh(color: StickerColor, face: Face): THREE.Mesh {
+  const geo = new THREE.PlaneGeometry(STICKER_SIZE, STICKER_SIZE);
+  const mat = new THREE.MeshStandardMaterial({
+    color: COLOR_HEX[color],
+    roughness: 0.45,
+    metalness: 0.0,
+    side: THREE.DoubleSide,
+  });
+  const mesh = new THREE.Mesh(geo, mat);
+  const [nx, ny, nz] = FACE_NORMAL[face];
+  mesh.position.set(nx * STICKER_INSET, ny * STICKER_INSET, nz * STICKER_INSET);
+  // Orient the plane so its normal matches the face direction
+  const axis = new THREE.Vector3(nx, ny, nz);
+  const quat = new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, 0, 1), axis);
+  mesh.quaternion.copy(quat);
+  mesh.userData.face = face;
+  return mesh;
+}
+
+export class CubeView {
+  readonly group: THREE.Group;
+  private cubies: Cubie[] = [];
+
+  constructor() {
+    this.group = new THREE.Group();
+    this.build();
+  }
+
+  private build(): void {
+    for (let x = -1; x <= 1; x++) {
+      for (let y = -1; y <= 1; y++) {
+        for (let z = -1; z <= 1; z++) {
+          const g = new THREE.Group();
+          g.position.set(x, y, z);
+          g.add(makeCubieBody());
+          const cubie: Cubie = { mesh: g, home: [x, y, z], stickers: new Map() };
+          this.cubies.push(cubie);
+          this.group.add(g);
+        }
+      }
+    }
+    this.repaintFromFacelets(this.solvedFacelets());
+  }
+
+  private cubieByHome(pos: Vec3): Cubie | null {
+    for (const c of this.cubies) {
+      if (c.home[0] === pos[0] && c.home[1] === pos[1] && c.home[2] === pos[2]) return c;
+    }
+    return null;
+  }
+
+  private solvedFacelets(): string {
+    return 'UUUUUUUUURRRRRRRRRFFFFFFFFFDDDDDDDDDLLLLLLLLLBBBBBBBBB';
+  }
+
+  /**
+   * Re-skin every cubie based on a 54-char facelet string (URFDLB).
+   * Used at startup and after a scan completes. Resets cubie orientations.
+   */
+  repaintFromFacelets(facelets: string): void {
+    if (facelets.length !== 54) throw new Error('expected 54 facelets');
+
+    // Reset every cubie back to its home pose, drop old stickers, reparent under root group.
+    for (const cubie of this.cubies) {
+      if (cubie.mesh.parent !== this.group) this.group.attach(cubie.mesh);
+      cubie.mesh.position.set(cubie.home[0], cubie.home[1], cubie.home[2]);
+      cubie.mesh.quaternion.identity();
+      cubie.stickers.forEach((s) => {
+        cubie.mesh.remove(s);
+        s.geometry.dispose();
+        (s.material as THREE.Material).dispose();
+      });
+      cubie.stickers.clear();
+    }
+
+    // For each facelet entry, find the cubie at its home position and add a sticker.
+    for (const entry of FACELET_MAP) {
+      const cubie = this.cubieByHome(entry.position);
+      if (!cubie) continue;
+      const letter = facelets[faceletGlobalIndex(entry.face, entry.index)];
+      const color = letterToColor(letter);
+      const sticker = makeStickerMesh(color, entry.face);
+      cubie.mesh.add(sticker);
+      cubie.stickers.set(entry.face, sticker);
+    }
+  }
+
+  /** Returns cubies whose current world position has the face's coord at ±1. */
+  getLayerCubies(face: Face): Cubie[] {
+    const axis = FACE_NORMAL[face];
+    const sign = axis[0] + axis[1] + axis[2]; // +1 or -1
+    const axisIdx = axis[0] !== 0 ? 0 : axis[1] !== 0 ? 1 : 2;
+    const out: Cubie[] = [];
+    for (const c of this.cubies) {
+      const p = c.mesh.position;
+      const v = axisIdx === 0 ? p.x : axisIdx === 1 ? p.y : p.z;
+      if (Math.abs(v - sign) < 0.1) out.push(c);
+    }
+    return out;
+  }
+
+  getAllCubies(): Cubie[] {
+    return this.cubies;
+  }
+
+  /** Snap each cubie's position to the integer lattice (called after baking a turn). */
+  snapAll(): void {
+    for (const c of this.cubies) {
+      c.mesh.position.x = Math.round(c.mesh.position.x);
+      c.mesh.position.y = Math.round(c.mesh.position.y);
+      c.mesh.position.z = Math.round(c.mesh.position.z);
+    }
+  }
+}
+
+function letterToColor(letter: string): StickerColor {
+  switch (letter) {
+    case 'U': return 'W';
+    case 'R': return 'R';
+    case 'F': return 'G';
+    case 'D': return 'Y';
+    case 'L': return 'O';
+    case 'B': return 'B';
+    default: throw new Error(`Unknown facelet letter "${letter}"`);
+  }
+}
+
+export const FACES_LIST: readonly Face[] = FACES;

--- a/src/cube/FaceletMap.ts
+++ b/src/cube/FaceletMap.ts
@@ -1,0 +1,61 @@
+import type { Face } from '../types';
+import { FACES } from '../types';
+
+export type Vec3 = [number, number, number];
+
+export interface FaceletEntry {
+  face: Face;
+  index: number;            // 0..8 within the face
+  position: Vec3;           // cubie lattice position {-1,0,1}^3
+  normal: Vec3;             // outward sticker normal
+}
+
+const NORMAL: Record<Face, Vec3> = {
+  U: [0, 1, 0],
+  R: [1, 0, 0],
+  F: [0, 0, 1],
+  D: [0, -1, 0],
+  L: [-1, 0, 0],
+  B: [0, 0, -1],
+};
+
+function cubiePosForFacelet(face: Face, r: number, c: number): Vec3 {
+  switch (face) {
+    case 'U': return [c - 1, +1, r - 1];
+    case 'R': return [+1, 1 - r, 1 - c];
+    case 'F': return [c - 1, 1 - r, +1];
+    case 'D': return [c - 1, -1, 1 - r];
+    case 'L': return [-1, 1 - r, c - 1];
+    case 'B': return [1 - c, 1 - r, -1];
+  }
+}
+
+export const FACELET_MAP: FaceletEntry[] = (() => {
+  const out: FaceletEntry[] = [];
+  for (const face of FACES) {
+    for (let r = 0; r < 3; r++) {
+      for (let c = 0; c < 3; c++) {
+        const idx = r * 3 + c;
+        out.push({
+          face,
+          index: idx,
+          position: cubiePosForFacelet(face, r, c),
+          normal: NORMAL[face],
+        });
+      }
+    }
+  }
+  return out;
+})();
+
+export function faceletGlobalIndex(face: Face, idx: number): number {
+  return FACES.indexOf(face) * 9 + idx;
+}
+
+export function eq(a: number, b: number, eps = 1e-3): boolean {
+  return Math.abs(a - b) < eps;
+}
+
+export function vecApprox(a: Vec3, b: Vec3, eps = 0.05): boolean {
+  return eq(a[0], b[0], eps) && eq(a[1], b[1], eps) && eq(a[2], b[2], eps);
+}

--- a/src/cube/MoveEngine.ts
+++ b/src/cube/MoveEngine.ts
@@ -1,0 +1,135 @@
+import * as THREE from 'three';
+import type { Face, Move } from '../types';
+import { CubeModel } from './CubeModel';
+import { CubeView, type Cubie } from './CubeView';
+import { easeInOutCubic } from '../util/math';
+import { bus } from '../app/events';
+
+const FACE_AXIS: Record<Face, THREE.Vector3> = {
+  U: new THREE.Vector3(0, 1, 0),
+  D: new THREE.Vector3(0, -1, 0),
+  R: new THREE.Vector3(1, 0, 0),
+  L: new THREE.Vector3(-1, 0, 0),
+  F: new THREE.Vector3(0, 0, 1),
+  B: new THREE.Vector3(0, 0, -1),
+};
+
+const ANIM_MS = 220;
+
+interface QueuedMove {
+  move: Move;
+  resolve: () => void;
+}
+
+export class MoveEngine {
+  private queue: QueuedMove[] = [];
+  private running = false;
+  private moveCount = 0;
+  private silentNextApply = false;
+
+  constructor(
+    private readonly view: CubeView,
+    private readonly model: CubeModel,
+    private readonly pivot: THREE.Group,
+  ) {}
+
+  resetCounter(): void {
+    this.moveCount = 0;
+  }
+
+  /** When the next applyMove is processed, do not emit move:applied. */
+  setSilent(): void {
+    this.silentNextApply = true;
+  }
+
+  queueMove(move: Move): Promise<void> {
+    return new Promise((resolve) => {
+      this.queue.push({ move, resolve });
+      if (!this.running) this.runNext();
+    });
+  }
+
+  async queueSequence(moves: Move[]): Promise<void> {
+    for (const m of moves) await this.queueMove(m);
+  }
+
+  isBusy(): boolean {
+    return this.running;
+  }
+
+  pendingCount(): number {
+    return this.queue.length;
+  }
+
+  private async runNext(): Promise<void> {
+    const item = this.queue.shift();
+    if (!item) {
+      this.running = false;
+      return;
+    }
+    this.running = true;
+    await this.animate(item.move);
+    item.resolve();
+    this.runNext();
+  }
+
+  private async animate(move: Move): Promise<void> {
+    const face = move[0] as Face;
+    const suffix = move.slice(1);
+    let angle = -Math.PI / 2;
+    if (suffix === "'") angle = +Math.PI / 2;
+    else if (suffix === '2') angle = -Math.PI;
+
+    // Sign correction: angle around face axis (outward) = standard CW for plain face.
+    // The rotation in three.js with axis = outward normal and negative angle gives
+    // a clockwise rotation when viewed from outside that face.
+    const axis = FACE_AXIS[face].clone().normalize();
+
+    const cubies = this.view.getLayerCubies(face);
+    // Reparent layer cubies to the pivot.
+    for (const c of cubies) this.pivot.attach(c.mesh);
+    this.pivot.quaternion.identity();
+
+    const start = performance.now();
+    const duration = suffix === '2' ? ANIM_MS * 1.4 : ANIM_MS;
+    const fromQ = new THREE.Quaternion();
+    const toQ = new THREE.Quaternion().setFromAxisAngle(axis, angle);
+
+    await new Promise<void>((resolve) => {
+      const tick = () => {
+        const t = Math.min(1, (performance.now() - start) / duration);
+        const eased = easeInOutCubic(t);
+        const q = new THREE.Quaternion().slerpQuaternions(fromQ, toQ, eased);
+        this.pivot.quaternion.copy(q);
+        if (t < 1) requestAnimationFrame(tick);
+        else resolve();
+      };
+      tick();
+    });
+
+    // Bake: reparent each cubie back to root, applying the pivot transform.
+    for (const c of cubies) this.snapBack(c);
+    this.pivot.quaternion.identity();
+    this.view.snapAll();
+
+    // Update logical model
+    this.model.applyMove(move);
+
+    if (this.silentNextApply) {
+      this.silentNextApply = false;
+    } else {
+      this.moveCount += 1;
+      bus.emit('move:applied', { move, total: this.moveCount });
+      if (this.model.isSolved()) bus.emit('cube:solved', undefined);
+    }
+  }
+
+  private snapBack(cubie: Cubie): void {
+    const root = this.pivot.parent!;
+    root.attach(cubie.mesh);
+    // Round position to lattice
+    cubie.mesh.position.x = Math.round(cubie.mesh.position.x);
+    cubie.mesh.position.y = Math.round(cubie.mesh.position.y);
+    cubie.mesh.position.z = Math.round(cubie.mesh.position.z);
+  }
+}

--- a/src/cube/Notation.ts
+++ b/src/cube/Notation.ts
@@ -1,0 +1,53 @@
+import type { Move, Face } from '../types';
+import { FACES } from '../types';
+
+const FACE_SET = new Set<Face>(FACES);
+
+export function parseSequence(input: string): Move[] {
+  if (!input.trim()) return [];
+  const tokens = input.trim().split(/\s+/);
+  const out: Move[] = [];
+  for (const tok of tokens) {
+    if (tok.length === 0) continue;
+    if (tok.length > 2) throw new Error(`Invalid move "${tok}"`);
+    const face = tok[0] as Face;
+    if (!FACE_SET.has(face)) throw new Error(`Invalid face "${tok[0]}"`);
+    if (tok.length === 1) {
+      out.push(face);
+    } else if (tok[1] === "'" || tok[1] === '2') {
+      out.push((face + tok[1]) as Move);
+    } else {
+      throw new Error(`Invalid suffix "${tok[1]}"`);
+    }
+  }
+  return out;
+}
+
+export function expandHalfTurns(moves: Move[]): Move[] {
+  const out: Move[] = [];
+  for (const m of moves) {
+    if (m.endsWith('2')) {
+      const face = m[0] as Face;
+      out.push(face, face);
+    } else {
+      out.push(m);
+    }
+  }
+  return out;
+}
+
+export function inverse(moves: Move[]): Move[] {
+  const out: Move[] = [];
+  for (let i = moves.length - 1; i >= 0; i--) {
+    const m = moves[i];
+    const face = m[0] as Face;
+    if (m.endsWith("'")) out.push(face);
+    else if (m.endsWith('2')) out.push(m);
+    else out.push(`${face}'` as Move);
+  }
+  return out;
+}
+
+export function movesToString(moves: Move[]): string {
+  return moves.join(' ');
+}

--- a/src/cube/Scrambler.ts
+++ b/src/cube/Scrambler.ts
@@ -1,0 +1,26 @@
+import type { Move, Face } from '../types';
+import { FACES } from '../types';
+
+const SUFFIXES = ['', "'", '2'] as const;
+
+const OPPOSITE: Record<Face, Face> = {
+  U: 'D', D: 'U',
+  R: 'L', L: 'R',
+  F: 'B', B: 'F',
+};
+
+export function generateScramble(length = 22): Move[] {
+  const out: Move[] = [];
+  let lastFace: Face | null = null;
+  let prevFace: Face | null = null;
+  while (out.length < length) {
+    const face = FACES[Math.floor(Math.random() * 6)];
+    if (face === lastFace) continue;
+    if (lastFace && OPPOSITE[face] === lastFace && prevFace === face) continue;
+    const suffix = SUFFIXES[Math.floor(Math.random() * 3)];
+    out.push(`${face}${suffix}` as Move);
+    prevFace = lastFace;
+    lastFace = face;
+  }
+  return out;
+}

--- a/src/cubejs.d.ts
+++ b/src/cubejs.d.ts
@@ -1,0 +1,25 @@
+declare module 'cubejs' {
+  type CubeJSON = unknown;
+
+  class Cube {
+    constructor(state?: CubeJSON);
+    move(arg: string | number | number[]): Cube;
+    asString(): string;
+    isSolved(): boolean;
+    clone(): Cube;
+    toJSON(): CubeJSON;
+    solve(maxDepth?: number): string;
+    solveUpright(maxDepth?: number): string;
+    upright(): string;
+    randomize(): Cube;
+    multiply(other: Cube): Cube;
+
+    static fromString(s: string): Cube;
+    static random(): Cube;
+    static initSolver(): void;
+    static scramble(): string;
+    static inverse(s: string | number | number[]): string | number[];
+  }
+
+  export default Cube;
+}

--- a/src/cv/HandTracker.ts
+++ b/src/cv/HandTracker.ts
@@ -1,0 +1,50 @@
+import { FilesetResolver, HandLandmarker, type HandLandmarkerResult } from '@mediapipe/tasks-vision';
+import { bus } from '../app/events';
+
+export class HandTracker {
+  private landmarker: HandLandmarker | null = null;
+  private lastTimestamp = 0;
+  private initPromise: Promise<void> | null = null;
+
+  async init(): Promise<void> {
+    if (this.initPromise) return this.initPromise;
+    this.initPromise = (async () => {
+      try {
+        const fileset = await FilesetResolver.forVisionTasks(`${import.meta.env.BASE_URL}wasm`);
+        this.landmarker = await HandLandmarker.createFromOptions(fileset, {
+          baseOptions: {
+            modelAssetPath: `${import.meta.env.BASE_URL}models/hand_landmarker.task`,
+            delegate: 'GPU',
+          },
+          numHands: 2,
+          runningMode: 'VIDEO',
+        });
+      } catch (err) {
+        bus.emit('cv:error', { message: `MediaPipe init: ${(err as Error).message}` });
+        throw err;
+      }
+    })();
+    return this.initPromise;
+  }
+
+  isReady(): boolean {
+    return this.landmarker !== null;
+  }
+
+  detect(video: HTMLVideoElement, now: number): HandLandmarkerResult | null {
+    if (!this.landmarker) return null;
+    if (video.readyState < 2) return null;
+    const ts = Math.max(this.lastTimestamp + 1, Math.floor(now));
+    this.lastTimestamp = ts;
+    try {
+      return this.landmarker.detectForVideo(video, ts);
+    } catch {
+      return null;
+    }
+  }
+
+  dispose(): void {
+    this.landmarker?.close();
+    this.landmarker = null;
+  }
+}

--- a/src/cv/Webcam.ts
+++ b/src/cv/Webcam.ts
@@ -1,0 +1,56 @@
+import { bus } from '../app/events';
+
+export class Webcam {
+  private stream: MediaStream | null = null;
+  private readyPromise: Promise<void> | null = null;
+
+  constructor(public readonly video: HTMLVideoElement) {}
+
+  async start(): Promise<void> {
+    if (this.stream) return;
+    try {
+      this.stream = await navigator.mediaDevices.getUserMedia({
+        video: { facingMode: 'user', width: { ideal: 640 }, height: { ideal: 480 } },
+        audio: false,
+      });
+    } catch (err) {
+      const e = err as DOMException;
+      let msg = e.message || 'No se pudo acceder a la cámara';
+      if (e.name === 'NotAllowedError') msg = 'Permiso de cámara denegado';
+      else if (e.name === 'NotFoundError') msg = 'No se encontró ninguna cámara';
+      bus.emit('cv:error', { message: msg });
+      throw err;
+    }
+    this.video.srcObject = this.stream;
+    this.readyPromise = new Promise<void>((resolve) => {
+      const onReady = () => {
+        this.video.removeEventListener('loadedmetadata', onReady);
+        this.video.play().then(() => resolve()).catch(() => resolve());
+      };
+      if (this.video.readyState >= 2) onReady();
+      else this.video.addEventListener('loadedmetadata', onReady);
+    });
+    await this.readyPromise;
+    bus.emit('cv:camera-on', undefined);
+  }
+
+  stop(): void {
+    if (!this.stream) return;
+    this.stream.getTracks().forEach((t) => t.stop());
+    this.stream = null;
+    this.video.srcObject = null;
+    bus.emit('cv:camera-off', undefined);
+  }
+
+  isOn(): boolean {
+    return this.stream !== null;
+  }
+
+  /** Width/height of the underlying video element, fallback to defaults. */
+  getSize(): { w: number; h: number } {
+    return {
+      w: this.video.videoWidth || 640,
+      h: this.video.videoHeight || 480,
+    };
+  }
+}

--- a/src/cv/gestures/GestureClassifier.ts
+++ b/src/cv/gestures/GestureClassifier.ts
@@ -1,0 +1,99 @@
+import type { HandLandmarkerResult } from '@mediapipe/tasks-vision';
+import type { GestureFrame, HandShape, Handedness, Landmark } from './types';
+
+const FINGER_TIPS = [4, 8, 12, 16, 20];
+const FINGER_PIPS = [3, 6, 10, 14, 18];
+const FINGER_MCPS = [2, 5, 9, 13, 17];
+const WRIST = 0;
+
+function dist(a: Landmark, b: Landmark): number {
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
+  const dz = a.z - b.z;
+  return Math.sqrt(dx * dx + dy * dy + dz * dz);
+}
+
+function isFingerExtended(landmarks: Landmark[], finger: number): boolean {
+  const tip = landmarks[FINGER_TIPS[finger]];
+  const pip = landmarks[FINGER_PIPS[finger]];
+  const mcp = landmarks[FINGER_MCPS[finger]];
+  const wrist = landmarks[WRIST];
+  const tipDist = dist(tip, wrist);
+  const pipDist = dist(pip, wrist);
+  const mcpDist = dist(mcp, wrist);
+  return tipDist > pipDist && pipDist > mcpDist * 0.95;
+}
+
+function classify(landmarks: Landmark[], hand: Handedness): HandShape {
+  const ext = [0, 1, 2, 3, 4].map((f) => isFingerExtended(landmarks, f));
+  const [thumbExt, indexExt, middleExt, ringExt, pinkyExt] = ext;
+  const wrist = landmarks[WRIST];
+  const indexTip = landmarks[8];
+  const indexMcp = landmarks[5];
+
+  const fingersExtCount = (indexExt ? 1 : 0) + (middleExt ? 1 : 0) + (ringExt ? 1 : 0) + (pinkyExt ? 1 : 0);
+
+  // Fist: no fingers extended (thumb optional)
+  if (fingersExtCount === 0) {
+    return { hand, shape: 'fist', wrist };
+  }
+
+  // Open palm: 4+ fingers extended
+  if (fingersExtCount >= 3 && thumbExt) {
+    // Determine palm orientation: cross product of (indexMcp - wrist) and (pinky_mcp - wrist)
+    const v1 = sub(landmarks[5], wrist);
+    const v2 = sub(landmarks[17], wrist);
+    const cross = crossZ(v1, v2);
+    // For Right hand, palm-towards-camera means the palm faces +Z (out of screen).
+    // Image coords: x grows right, y grows down. Cross sign indicates orientation.
+    const palmIn = (hand === 'Right' ? cross > 0 : cross < 0);
+    return { hand, shape: palmIn ? 'palmIn' : 'palmOut', wrist };
+  }
+
+  // Thumb up/down: thumb extended, others curled
+  if (thumbExt && fingersExtCount === 0) {
+    const thumbTip = landmarks[4];
+    if (thumbTip.y < wrist.y - 0.08) return { hand, shape: 'thumbUp', wrist };
+    if (thumbTip.y > wrist.y + 0.08) return { hand, shape: 'thumbDown', wrist };
+  }
+
+  // Pointing: index extended, others curled
+  if (indexExt && !middleExt && !ringExt && !pinkyExt) {
+    const dx = indexTip.x - indexMcp.x;
+    const dy = indexTip.y - indexMcp.y;
+    const ax = Math.abs(dx);
+    const ay = Math.abs(dy);
+    if (ay > ax) {
+      return { hand, shape: dy < 0 ? 'pointUp' : 'pointDown', wrist };
+    } else {
+      // In image coords, +x is right of the *frame*. Selfie video is mirrored visually,
+      // but landmarks are not — interpret using handedness info downstream.
+      return { hand, shape: dx < 0 ? 'pointLeft' : 'pointRight', wrist };
+    }
+  }
+
+  return { hand, shape: 'unknown', wrist };
+}
+
+function sub(a: Landmark, b: Landmark): Landmark {
+  return { x: a.x - b.x, y: a.y - b.y, z: a.z - b.z };
+}
+
+function crossZ(a: Landmark, b: Landmark): number {
+  return a.x * b.y - a.y * b.x;
+}
+
+export class GestureClassifier {
+  classify(result: HandLandmarkerResult, ts: number): GestureFrame {
+    const hands: HandShape[] = [];
+    if (result.landmarks && result.landmarks.length > 0) {
+      for (let i = 0; i < result.landmarks.length; i++) {
+        const lm = result.landmarks[i] as Landmark[];
+        const h = result.handedness?.[i]?.[0]?.categoryName as Handedness | undefined;
+        if (!h) continue;
+        hands.push(classify(lm, h));
+      }
+    }
+    return { hands, ts };
+  }
+}

--- a/src/cv/gestures/GestureMapper.ts
+++ b/src/cv/gestures/GestureMapper.ts
@@ -1,0 +1,134 @@
+import type { Face, Move } from '../../types';
+import type { GestureFrame, HandShape, Handedness } from './types';
+import { bus } from '../../app/events';
+
+type State = 'idle' | 'face-selected' | 'cooldown';
+
+const FACE_FROM_LEFT_SHAPE: Record<string, Face | null> = {
+  pointUp: 'U',
+  pointRight: 'R',
+  palmOut: 'F',
+  pointDown: 'D',
+  pointLeft: 'L',
+  palmIn: 'B',
+  fist: null,
+  thumbUp: null,
+  thumbDown: null,
+  open: null,
+  unknown: null,
+  pointUp_neutral: null,
+};
+
+const HOLD_FRAMES = 5;
+const COOLDOWN_MS = 350;
+const SWIPE_BUFFER = 6;
+const SWIPE_DX_MIN = 0.18;
+
+interface WristSample { x: number; y: number; ts: number }
+
+export interface GestureMapperEvents {
+  onFaceSelected?: (face: Face | null) => void;
+  onMove: (move: Move) => void;
+}
+
+export class GestureMapper {
+  private state: State = 'idle';
+  private heldFace: Face | null = null;
+  private holdCount = 0;
+  private cooldownUntil = 0;
+  private rightWrist: WristSample[] = [];
+
+  constructor(private readonly events: GestureMapperEvents) {}
+
+  process(frame: GestureFrame): void {
+    if (frame.ts < this.cooldownUntil) return;
+    if (this.state === 'cooldown') {
+      this.state = 'idle';
+    }
+
+    const left = pickHand(frame.hands, 'Left');
+    const right = pickHand(frame.hands, 'Right');
+
+    // Update wrist buffer for right hand
+    if (right) {
+      this.rightWrist.push({ x: right.wrist.x, y: right.wrist.y, ts: frame.ts });
+      if (this.rightWrist.length > SWIPE_BUFFER) this.rightWrist.shift();
+    } else {
+      this.rightWrist = [];
+    }
+
+    // Determine candidate face from left hand
+    const candidate = left ? FACE_FROM_LEFT_SHAPE[left.shape] : null;
+    if (candidate !== this.heldFace) {
+      this.heldFace = candidate;
+      this.holdCount = 0;
+    } else if (candidate) {
+      this.holdCount += 1;
+    }
+
+    // Update selection event
+    if (this.heldFace && this.holdCount === HOLD_FRAMES) {
+      this.state = 'face-selected';
+      this.events.onFaceSelected?.(this.heldFace);
+    }
+    if (!this.heldFace && this.state === 'face-selected') {
+      this.state = 'idle';
+      this.events.onFaceSelected?.(null);
+    }
+
+    // If face selected, look for direction commit
+    if (this.state === 'face-selected' && right) {
+      const dir = this.detectDirection(right);
+      if (dir) {
+        const move = (dir === 'CW' ? this.heldFace! : `${this.heldFace!}'`) as Move;
+        bus.emit('toast', { message: `Gesto → ${move}`, kind: 'info' });
+        this.events.onMove(move);
+        this.commit(move, frame.ts);
+      }
+    }
+
+    // Cancel: left hand fist while in face-selected
+    if (this.state === 'face-selected' && left?.shape === 'fist') {
+      this.state = 'idle';
+      this.heldFace = null;
+      this.holdCount = 0;
+      this.events.onFaceSelected?.(null);
+    }
+  }
+
+  /** Set when MoveEngine actually animates the move; resolves race condition. */
+  notifyMoveApplied(_move: Move): void {
+    /* no-op for now; left here for future bookkeeping */
+  }
+
+  private detectDirection(right: HandShape): 'CW' | 'CCW' | null {
+    if (right.shape === 'thumbUp') return 'CW';
+    if (right.shape === 'thumbDown') return 'CCW';
+    if (this.rightWrist.length === SWIPE_BUFFER) {
+      const dx = this.rightWrist[SWIPE_BUFFER - 1].x - this.rightWrist[0].x;
+      const dy = Math.abs(this.rightWrist[SWIPE_BUFFER - 1].y - this.rightWrist[0].y);
+      if (Math.abs(dx) > SWIPE_DX_MIN && dy < 0.1) {
+        // Note: image coords +x = right in original frame; selfie display is mirrored,
+        // so a "swipe right" in user's view corresponds to dx < 0 in landmarks.
+        return dx < 0 ? 'CW' : 'CCW';
+      }
+    }
+    return null;
+  }
+
+  private commit(_move: Move, ts: number): void {
+    this.cooldownUntil = ts + COOLDOWN_MS;
+    this.state = 'cooldown';
+    this.heldFace = null;
+    this.holdCount = 0;
+    this.rightWrist = [];
+    this.events.onFaceSelected?.(null);
+  }
+}
+
+function pickHand(hands: HandShape[], h: Handedness): HandShape | null {
+  for (const x of hands) if (x.hand === h) return x;
+  return null;
+}
+
+export const FACE_FROM_LEFT_SHAPE_PUBLIC = FACE_FROM_LEFT_SHAPE;

--- a/src/cv/gestures/types.ts
+++ b/src/cv/gestures/types.ts
@@ -1,0 +1,25 @@
+import type { Face, Move } from '../../types';
+
+export type Handedness = 'Left' | 'Right';
+
+export interface Landmark { x: number; y: number; z: number }
+
+export type FingerCurl = 'extended' | 'curled';
+
+export interface HandShape {
+  hand: Handedness;
+  shape: 'fist' | 'open' | 'pointUp' | 'pointDown' | 'pointLeft' | 'pointRight' | 'thumbUp' | 'thumbDown' | 'palmIn' | 'palmOut' | 'unknown';
+  wrist: Landmark;
+}
+
+export interface GestureFrame {
+  hands: HandShape[];
+  ts: number;
+}
+
+export interface PendingMove {
+  face: Face;
+  dir: 'CW' | 'CCW' | '180';
+}
+
+export type EmitMove = (move: Move) => void;

--- a/src/cv/scan/ColorClassifier.ts
+++ b/src/cv/scan/ColorClassifier.ts
@@ -1,0 +1,86 @@
+import type { StickerColor } from '../../types';
+import type { RGB, HSV } from '../../util/color';
+import { rgbToHsv, hueDist } from '../../util/color';
+
+/**
+ * Center-anchored HSV classifier.
+ *
+ * 1. Identifies the 6 center stickers by HSV rules.
+ * 2. Classifies the remaining 48 by weighted HSV distance to the 6 centers,
+ *    so it adapts to lighting (the centers ARE the per-session reference).
+ * 3. Validates color counts (each must appear 9 times).
+ */
+export class ColorClassifier {
+  classify(samples54: RGB[]): { stickers: StickerColor[]; ok: boolean; reason?: string } {
+    if (samples54.length !== 54) throw new Error('expected 54 samples');
+    const hsv: HSV[] = samples54.map((s) => rgbToHsv(s));
+
+    const centerIdxs = [4, 13, 22, 31, 40, 49];
+    const centerHsv = centerIdxs.map((i) => hsv[i]);
+
+    const centerLabels = centerHsv.map((h) => labelByHsvRule(h));
+    const labelSet = new Set(centerLabels);
+    if (labelSet.size !== 6 || centerLabels.includes(null as unknown as StickerColor)) {
+      return {
+        stickers: [],
+        ok: false,
+        reason: 'Centros ambiguos: revisa la iluminación o vuelve a escanear.',
+      };
+    }
+
+    const stickers: StickerColor[] = new Array(54);
+    for (let i = 0; i < 54; i++) {
+      const ci = centerIdxs.indexOf(i);
+      if (ci !== -1) {
+        stickers[i] = centerLabels[ci]!;
+      } else {
+        let best = 0;
+        let bestD = Infinity;
+        for (let k = 0; k < 6; k++) {
+          const d = hsvDist(hsv[i], centerHsv[k]);
+          if (d < bestD) {
+            bestD = d;
+            best = k;
+          }
+        }
+        stickers[i] = centerLabels[best]!;
+      }
+    }
+
+    const counts: Record<StickerColor, number> = { W: 0, Y: 0, R: 0, O: 0, G: 0, B: 0 };
+    for (const s of stickers) counts[s]++;
+    for (const c of Object.keys(counts) as StickerColor[]) {
+      if (counts[c] !== 9) {
+        return {
+          stickers,
+          ok: false,
+          reason: `Conteos inválidos (${c}=${counts[c]}). Reintenta el escaneo.`,
+        };
+      }
+    }
+
+    return { stickers, ok: true };
+  }
+}
+
+function labelByHsvRule(h: HSV): StickerColor | null {
+  if (h.v < 0.18) return null;
+  if (h.s < 0.22 && h.v > 0.55) return 'W';
+  if (h.s < 0.22) return null;
+  const hue = h.h;
+  if (hue < 15 || hue >= 340) return 'R';
+  if (hue >= 15 && hue < 38) return 'O';
+  if (hue >= 38 && hue < 75) return 'Y';
+  if (hue >= 75 && hue < 170) return 'G';
+  if (hue >= 170 && hue < 265) return 'B';
+  // 265-340 falls in red/magenta range; treat as R if very saturated.
+  return 'R';
+}
+
+function hsvDist(a: HSV, b: HSV): number {
+  const hueWeight = a.s > 0.25 && b.s > 0.25 ? 2.0 : 0;
+  const dh = hueDist(a.h, b.h) / 180; // normalize to 0..1
+  const ds = Math.abs(a.s - b.s);
+  const dv = Math.abs(a.v - b.v);
+  return hueWeight * dh * dh + 1.0 * ds * ds + 0.7 * dv * dv;
+}

--- a/src/cv/scan/ColorSampler.ts
+++ b/src/cv/scan/ColorSampler.ts
@@ -1,0 +1,68 @@
+import type { RGB } from '../../util/color';
+import { medianRgb } from '../../util/color';
+
+const PATCH = 5;            // 5x5 px
+const SAMPLES_PER_CELL = 5; // center + 4 nearby
+
+/**
+ * Sample 9 colors from a video frame inside a centered 3x3 grid.
+ * Reads from an offscreen, *unmirrored* canvas, regardless of how the
+ * preview is displayed. Returns 9 RGB colors in row-major order.
+ */
+export class ColorSampler {
+  private offscreen: HTMLCanvasElement;
+  private ctx: CanvasRenderingContext2D;
+
+  constructor() {
+    this.offscreen = document.createElement('canvas');
+    this.ctx = this.offscreen.getContext('2d', { willReadFrequently: true })!;
+  }
+
+  capture(video: HTMLVideoElement): RGB[] {
+    const w = video.videoWidth || 640;
+    const h = video.videoHeight || 480;
+    if (this.offscreen.width !== w) this.offscreen.width = w;
+    if (this.offscreen.height !== h) this.offscreen.height = h;
+    this.ctx.drawImage(video, 0, 0, w, h);
+
+    const size = Math.floor(Math.min(w, h) * 0.7);
+    const x0 = Math.floor((w - size) / 2);
+    const y0 = Math.floor((h - size) / 2);
+    const cell = size / 3;
+
+    const out: RGB[] = [];
+    for (let r = 0; r < 3; r++) {
+      for (let c = 0; c < 3; c++) {
+        const cx = x0 + c * cell + cell / 2;
+        const cy = y0 + r * cell + cell / 2;
+        const samples: RGB[] = [];
+        const offsets = [
+          [0, 0],
+          [-cell * 0.18, -cell * 0.18],
+          [cell * 0.18, -cell * 0.18],
+          [-cell * 0.18, cell * 0.18],
+          [cell * 0.18, cell * 0.18],
+        ];
+        for (let i = 0; i < SAMPLES_PER_CELL; i++) {
+          const px = Math.round(cx + offsets[i][0] - PATCH / 2);
+          const py = Math.round(cy + offsets[i][1] - PATCH / 2);
+          samples.push(this.averagePatch(px, py));
+        }
+        out.push(medianRgb(samples));
+      }
+    }
+    return out;
+  }
+
+  private averagePatch(x: number, y: number): RGB {
+    const data = this.ctx.getImageData(x, y, PATCH, PATCH).data;
+    let r = 0, g = 0, b = 0;
+    const n = PATCH * PATCH;
+    for (let i = 0; i < n; i++) {
+      r += data[i * 4];
+      g += data[i * 4 + 1];
+      b += data[i * 4 + 2];
+    }
+    return { r: r / n, g: g / n, b: b / n };
+  }
+}

--- a/src/cv/scan/GridOverlay.ts
+++ b/src/cv/scan/GridOverlay.ts
@@ -1,0 +1,69 @@
+import type { Face } from '../../types';
+
+const FACE_LABELS: Record<Face, string> = {
+  U: 'Cara U (centro blanco)',
+  R: 'Cara R (centro rojo)',
+  F: 'Cara F (centro verde)',
+  D: 'Cara D (centro amarillo)',
+  L: 'Cara L (centro naranja)',
+  B: 'Cara B (centro azul)',
+};
+
+export class GridOverlay {
+  private ctx: CanvasRenderingContext2D;
+
+  constructor(private readonly canvas: HTMLCanvasElement) {
+    this.ctx = canvas.getContext('2d')!;
+  }
+
+  resize(w: number, h: number): void {
+    if (this.canvas.width !== w) this.canvas.width = w;
+    if (this.canvas.height !== h) this.canvas.height = h;
+  }
+
+  /** Returns the pixel rectangle of the 3x3 sampling area, in canvas coords. */
+  computeRect(): { x: number; y: number; size: number } {
+    const w = this.canvas.width;
+    const h = this.canvas.height;
+    const size = Math.floor(Math.min(w, h) * 0.7);
+    return { x: Math.floor((w - size) / 2), y: Math.floor((h - size) / 2), size };
+  }
+
+  draw(face: Face): void {
+    const { x, y, size } = this.computeRect();
+    const ctx = this.ctx;
+    ctx.save();
+    // The video is shown mirrored via CSS (scaleX(-1)), so mirror the canvas too
+    // for a consistent visual frame.
+    ctx.setTransform(-1, 0, 0, 1, this.canvas.width, 0);
+    ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+
+    ctx.lineWidth = 2;
+    ctx.strokeStyle = 'rgba(255, 255, 255, 0.85)';
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.18)';
+    const cell = size / 3;
+    for (let r = 0; r < 3; r++) {
+      for (let c = 0; c < 3; c++) {
+        const cx = x + c * cell;
+        const cy = y + r * cell;
+        ctx.fillRect(cx, cy, cell, cell);
+        ctx.strokeRect(cx, cy, cell, cell);
+      }
+    }
+    ctx.restore();
+
+    // Label (drawn unmirrored)
+    ctx.save();
+    ctx.fillStyle = 'rgba(0,0,0,0.6)';
+    ctx.fillRect(0, 0, this.canvas.width, 28);
+    ctx.fillStyle = '#fff';
+    ctx.font = '13px ui-sans-serif, system-ui, sans-serif';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(FACE_LABELS[face], 8, 14);
+    ctx.restore();
+  }
+
+  clear(): void {
+    this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+  }
+}

--- a/src/cv/scan/ScanController.ts
+++ b/src/cv/scan/ScanController.ts
@@ -1,0 +1,105 @@
+import type { Face, StickerColor } from '../../types';
+import type { Webcam } from '../Webcam';
+import { ColorSampler } from './ColorSampler';
+import { ColorClassifier } from './ColorClassifier';
+import { GridOverlay } from './GridOverlay';
+import { bus } from '../../app/events';
+
+/** Scan order matches cubejs facelet ordering: U, R, F, D, L, B. */
+const SCAN_ORDER: Face[] = ['U', 'R', 'F', 'D', 'L', 'B'];
+
+const FACE_LABEL: Record<Face, string> = {
+  U: 'Cara U (blanca, arriba)',
+  R: 'Cara R (roja, derecha)',
+  F: 'Cara F (verde, frente)',
+  D: 'Cara D (amarilla, abajo)',
+  L: 'Cara L (naranja, izquierda)',
+  B: 'Cara B (azul, atrás)',
+};
+
+export interface ScanResult {
+  stickers54: StickerColor[];
+}
+
+export class ScanController {
+  private current = 0;
+  private buffer: StickerColor[] = [];
+  private sampler = new ColorSampler();
+  private classifier = new ColorClassifier();
+  private rawByFace: { face: Face; rgbs: ReturnType<ColorSampler['capture']> }[] = [];
+
+  constructor(
+    private readonly webcam: Webcam,
+    private readonly overlay: GridOverlay,
+    private readonly onComplete: (res: ScanResult) => void,
+  ) {}
+
+  start(): void {
+    this.current = 0;
+    this.buffer = [];
+    this.rawByFace = [];
+    this.refresh();
+  }
+
+  reset(): void {
+    this.start();
+  }
+
+  /** Trigger a capture of the current face. Advances internal state. */
+  capture(): void {
+    if (!this.webcam.isOn()) {
+      bus.emit('toast', { message: 'Activa la cámara primero', kind: 'warn' });
+      return;
+    }
+    const face = SCAN_ORDER[this.current];
+    const rgbs = this.sampler.capture(this.webcam.video);
+    this.rawByFace.push({ face, rgbs });
+    this.current += 1;
+
+    if (this.current >= SCAN_ORDER.length) {
+      this.classifyAll();
+    } else {
+      bus.emit('scan:progress', { faceIndex: this.current, total: 6 });
+      this.refresh();
+    }
+  }
+
+  /** Render the grid overlay for the current face. */
+  refresh(): void {
+    if (this.current < SCAN_ORDER.length) {
+      const face = SCAN_ORDER[this.current];
+      const { w, h } = this.webcam.getSize();
+      this.overlay.resize(w, h);
+      this.overlay.draw(face);
+      bus.emit('scan:progress', { faceIndex: this.current, total: 6 });
+    } else {
+      this.overlay.clear();
+    }
+  }
+
+  faceLabel(): string {
+    if (this.current >= SCAN_ORDER.length) return 'Procesando…';
+    return FACE_LABEL[SCAN_ORDER[this.current]];
+  }
+
+  isComplete(): boolean {
+    return this.current >= SCAN_ORDER.length;
+  }
+
+  private classifyAll(): void {
+    const all: ReturnType<ColorSampler['capture']> = [];
+    for (const f of SCAN_ORDER) {
+      const entry = this.rawByFace.find((e) => e.face === f)!;
+      all.push(...entry.rgbs);
+    }
+    const result = this.classifier.classify(all);
+    if (!result.ok) {
+      bus.emit('toast', { message: result.reason ?? 'Escaneo inválido', kind: 'error' });
+      this.start();
+      return;
+    }
+    this.buffer = result.stickers;
+    bus.emit('scan:complete', undefined);
+    this.onComplete({ stickers54: this.buffer });
+  }
+}

--- a/src/hud/Hud.ts
+++ b/src/hud/Hud.ts
@@ -1,0 +1,169 @@
+import type { Mode } from '../types';
+import { bus } from '../app/events';
+import { Timer } from './Timer';
+import { MoveCounter } from './MoveCounter';
+
+export interface HudHandlers {
+  onScramble: () => void;
+  onReset: () => void;
+  onSolve: () => void;
+  onModeChange: (m: Mode) => void;
+  onCameraToggle: () => void;
+  onScanCapture: () => void;
+  onScanRestart: () => void;
+}
+
+export class Hud {
+  readonly timer: Timer;
+  readonly moves: MoveCounter;
+  private modeButtons: Record<Mode, HTMLButtonElement>;
+  private cameraBtn: HTMLButtonElement;
+  private solveBtn: HTMLButtonElement;
+  private scrambleBtn: HTMLButtonElement;
+  private scanPanel: HTMLDivElement;
+  private gestureHint: HTMLDivElement;
+  private toastEl: HTMLDivElement;
+  private toastTimeout: number | null = null;
+
+  constructor(root: HTMLElement, handlers: HudHandlers) {
+    const bar = document.createElement('div');
+    bar.className = 'hud-bar';
+    bar.innerHTML = `
+      <div class="hud-stat"><span class="hud-label">Tiempo</span><span class="hud-value" id="hud-time">0:00.00</span></div>
+      <div class="hud-stat"><span class="hud-label">Mov.</span><span class="hud-value" id="hud-moves">0</span></div>
+      <button class="hud-btn" id="hud-scramble">Mezclar</button>
+      <button class="hud-btn" id="hud-reset">Reset</button>
+      <button class="hud-btn primary" id="hud-solve">Resolver</button>
+      <div class="hud-mode" id="hud-mode">
+        <button data-mode="mouse" class="active">Ratón</button>
+        <button data-mode="gestures">Gestos</button>
+        <button data-mode="scan">Escanear</button>
+      </div>
+      <button class="hud-btn" id="hud-camera">Cámara on</button>
+    `;
+    root.appendChild(bar);
+
+    this.timer = new Timer(bar.querySelector('#hud-time')!);
+    this.moves = new MoveCounter(bar.querySelector('#hud-moves')!);
+
+    this.scrambleBtn = bar.querySelector<HTMLButtonElement>('#hud-scramble')!;
+    this.scrambleBtn.addEventListener('click', handlers.onScramble);
+
+    bar.querySelector<HTMLButtonElement>('#hud-reset')!.addEventListener('click', handlers.onReset);
+
+    this.solveBtn = bar.querySelector<HTMLButtonElement>('#hud-solve')!;
+    this.solveBtn.addEventListener('click', handlers.onSolve);
+    this.solveBtn.disabled = true;
+
+    this.modeButtons = {
+      mouse: bar.querySelector<HTMLButtonElement>('button[data-mode="mouse"]')!,
+      gestures: bar.querySelector<HTMLButtonElement>('button[data-mode="gestures"]')!,
+      scan: bar.querySelector<HTMLButtonElement>('button[data-mode="scan"]')!,
+    };
+    for (const m of ['mouse', 'gestures', 'scan'] as Mode[]) {
+      this.modeButtons[m].addEventListener('click', () => handlers.onModeChange(m));
+    }
+
+    this.cameraBtn = bar.querySelector<HTMLButtonElement>('#hud-camera')!;
+    this.cameraBtn.addEventListener('click', handlers.onCameraToggle);
+
+    this.scanPanel = document.createElement('div');
+    this.scanPanel.id = 'scan-panel';
+    this.scanPanel.innerHTML = `
+      <h3>Escaneo del cubo</h3>
+      <div class="progress" id="scan-progress"></div>
+      <p id="scan-msg">Muestra la cara <b>U</b> (blanca) hacia la cámara y pulsa <kbd>Espacio</kbd> o el botón.</p>
+      <div class="actions">
+        <button class="hud-btn primary" id="scan-capture">Capturar</button>
+        <button class="hud-btn" id="scan-restart">Reiniciar</button>
+      </div>
+    `;
+    document.getElementById('hud-root')!.appendChild(this.scanPanel);
+    this.scanPanel.querySelector<HTMLButtonElement>('#scan-capture')!.addEventListener('click', handlers.onScanCapture);
+    this.scanPanel.querySelector<HTMLButtonElement>('#scan-restart')!.addEventListener('click', handlers.onScanRestart);
+
+    this.gestureHint = document.createElement('div');
+    this.gestureHint.id = 'gesture-hint';
+    this.gestureHint.innerHTML = `
+      <h3>Modo gestos (dos manos)</h3>
+      <p>
+        <b>Izquierda</b> elige cara: índice ↑ <code>U</code>, → <code>R</code>, ↓ <code>D</code>, ← <code>L</code>;
+        palma hacia ti <code>F</code>, palma fuera <code>B</code>.<br/>
+        <b>Derecha</b> confirma: 👍 / swipe der → <b>CW</b>; 👎 / swipe izq → <b>CCW</b>.
+      </p>
+    `;
+    document.getElementById('hud-root')!.appendChild(this.gestureHint);
+
+    this.toastEl = document.getElementById('toast') as HTMLDivElement;
+
+    this.bindEvents();
+  }
+
+  private bindEvents(): void {
+    bus.on('move:applied', () => {
+      this.moves.increment();
+      if (!this.timer.isRunning()) this.timer.startNow();
+    });
+    bus.on('cube:solved', () => {
+      this.timer.pause();
+      this.toast('¡Resuelto! 🎉', 'info');
+    });
+    bus.on('cube:reset', () => {
+      this.timer.reset();
+      this.moves.reset();
+    });
+    bus.on('cube:scrambled', () => {
+      this.timer.reset();
+      this.moves.reset();
+    });
+    bus.on('solver:ready', () => {
+      this.solveBtn.disabled = false;
+    });
+    bus.on('solver:solving', () => {
+      this.solveBtn.disabled = true;
+      this.solveBtn.textContent = 'Resolviendo…';
+    });
+    bus.on('solver:solution', () => {
+      this.solveBtn.disabled = false;
+      this.solveBtn.textContent = 'Resolver';
+    });
+    bus.on('solver:error', ({ message }) => {
+      this.solveBtn.disabled = false;
+      this.solveBtn.textContent = 'Resolver';
+      this.toast(`Solver: ${message}`, 'error');
+    });
+    bus.on('cv:error', ({ message }) => this.toast(`CV: ${message}`, 'error'));
+    bus.on('cv:camera-on', () => (this.cameraBtn.textContent = 'Cámara off'));
+    bus.on('cv:camera-off', () => (this.cameraBtn.textContent = 'Cámara on'));
+    bus.on('toast', ({ message, kind }) => this.toast(message, kind ?? 'info'));
+  }
+
+  setMode(m: Mode): void {
+    for (const k of Object.keys(this.modeButtons) as Mode[]) {
+      this.modeButtons[k].classList.toggle('active', k === m);
+    }
+    this.scanPanel.classList.toggle('active', m === 'scan');
+    this.gestureHint.classList.toggle('active', m === 'gestures');
+  }
+
+  setScanProgress(faceIndex: number, total: number, msg: string): void {
+    const prog = this.scanPanel.querySelector<HTMLDivElement>('#scan-progress')!;
+    prog.innerHTML = '';
+    for (let i = 0; i < total; i++) {
+      const span = document.createElement('span');
+      if (i < faceIndex) span.className = 'done';
+      else if (i === faceIndex) span.className = 'current';
+      prog.appendChild(span);
+    }
+    this.scanPanel.querySelector<HTMLElement>('#scan-msg')!.innerHTML = msg;
+  }
+
+  toast(message: string, kind: 'info' | 'warn' | 'error' = 'info'): void {
+    this.toastEl.textContent = message;
+    this.toastEl.className = `show ${kind}`;
+    if (this.toastTimeout) window.clearTimeout(this.toastTimeout);
+    this.toastTimeout = window.setTimeout(() => {
+      this.toastEl.className = '';
+    }, 2400);
+  }
+}

--- a/src/hud/MoveCounter.ts
+++ b/src/hud/MoveCounter.ts
@@ -1,0 +1,21 @@
+export class MoveCounter {
+  private count = 0;
+
+  constructor(private readonly el: HTMLElement) {
+    this.render();
+  }
+
+  increment(): void {
+    this.count += 1;
+    this.render();
+  }
+
+  reset(): void {
+    this.count = 0;
+    this.render();
+  }
+
+  private render(): void {
+    this.el.textContent = String(this.count);
+  }
+}

--- a/src/hud/Timer.ts
+++ b/src/hud/Timer.ts
@@ -1,0 +1,50 @@
+export class Timer {
+  private start: number | null = null;
+  private elapsed = 0;
+  private rafId: number | null = null;
+
+  constructor(private readonly el: HTMLElement) {
+    this.render();
+  }
+
+  startNow(): void {
+    if (this.start !== null) return;
+    this.start = performance.now();
+    this.tick();
+  }
+
+  pause(): void {
+    if (this.start === null) return;
+    this.elapsed += performance.now() - this.start;
+    this.start = null;
+    if (this.rafId) cancelAnimationFrame(this.rafId);
+    this.rafId = null;
+    this.render();
+  }
+
+  reset(): void {
+    this.start = null;
+    this.elapsed = 0;
+    if (this.rafId) cancelAnimationFrame(this.rafId);
+    this.rafId = null;
+    this.render();
+  }
+
+  isRunning(): boolean {
+    return this.start !== null;
+  }
+
+  private tick = (): void => {
+    this.render();
+    if (this.start !== null) this.rafId = requestAnimationFrame(this.tick);
+  };
+
+  private render(): void {
+    const total = this.elapsed + (this.start !== null ? performance.now() - this.start : 0);
+    const seconds = total / 1000;
+    const m = Math.floor(seconds / 60);
+    const s = Math.floor(seconds % 60);
+    const cs = Math.floor((seconds * 100) % 100);
+    this.el.textContent = `${m}:${s.toString().padStart(2, '0')}.${cs.toString().padStart(2, '0')}`;
+  }
+}

--- a/src/hud/hud.css
+++ b/src/hud/hud.css
@@ -1,0 +1,239 @@
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  background: #0b0d12;
+  color: #e6e9f0;
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  overflow: hidden;
+  user-select: none;
+}
+
+#app {
+  position: relative;
+  width: 100vw;
+  height: 100vh;
+  overflow: hidden;
+}
+
+#three-canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+  touch-action: none;
+}
+
+#cv-layer {
+  position: absolute;
+  right: 16px;
+  bottom: 16px;
+  width: 320px;
+  max-width: 36vw;
+  aspect-ratio: 4 / 3;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #000;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+  display: none;
+  z-index: 5;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+#cv-layer.scan-mode {
+  width: min(420px, 60vw);
+}
+
+#cv-layer.active {
+  display: block;
+}
+
+#cv-video {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transform: scaleX(-1);
+}
+
+#cv-overlay {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+#hud-root {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 10;
+}
+
+.hud-bar {
+  position: absolute;
+  top: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  background: rgba(20, 22, 30, 0.78);
+  backdrop-filter: blur(8px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 14px;
+  pointer-events: auto;
+  flex-wrap: wrap;
+  max-width: calc(100vw - 24px);
+  justify-content: center;
+}
+
+.hud-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 4px 10px;
+  border-right: 1px solid rgba(255, 255, 255, 0.08);
+}
+.hud-stat:last-of-type { border-right: 0; }
+
+.hud-label {
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.55;
+}
+
+.hud-value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  font-size: 16px;
+}
+
+.hud-btn {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: inherit;
+  padding: 8px 12px;
+  border-radius: 10px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+.hud-btn:hover { background: rgba(255, 255, 255, 0.1); }
+.hud-btn:disabled { opacity: 0.45; cursor: not-allowed; }
+.hud-btn.primary { background: #2563eb; border-color: #2563eb; }
+.hud-btn.primary:hover { background: #1d4ed8; }
+.hud-btn.warn { background: #b45309; border-color: #b45309; }
+
+.hud-mode {
+  display: flex;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  overflow: hidden;
+}
+.hud-mode button {
+  background: transparent;
+  border: 0;
+  color: inherit;
+  padding: 8px 10px;
+  font-size: 12px;
+  cursor: pointer;
+}
+.hud-mode button.active {
+  background: rgba(37, 99, 235, 0.85);
+}
+
+#scan-panel {
+  position: absolute;
+  left: 12px;
+  bottom: 12px;
+  background: rgba(20, 22, 30, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  padding: 12px 14px;
+  pointer-events: auto;
+  display: none;
+  max-width: 320px;
+  font-size: 13px;
+  z-index: 11;
+}
+#scan-panel.active { display: block; }
+#scan-panel h3 { margin: 0 0 6px 0; font-size: 14px; }
+#scan-panel p { margin: 0 0 10px 0; opacity: 0.78; line-height: 1.4; }
+#scan-panel .progress {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 8px;
+}
+#scan-panel .progress span {
+  flex: 1;
+  height: 6px;
+  border-radius: 3px;
+  background: rgba(255, 255, 255, 0.1);
+}
+#scan-panel .progress span.done { background: #22c55e; }
+#scan-panel .progress span.current { background: #2563eb; }
+#scan-panel .actions {
+  display: flex;
+  gap: 8px;
+}
+
+#gesture-hint {
+  position: absolute;
+  left: 12px;
+  bottom: 12px;
+  background: rgba(20, 22, 30, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  padding: 12px 14px;
+  pointer-events: auto;
+  display: none;
+  max-width: 320px;
+  font-size: 12px;
+  line-height: 1.5;
+  z-index: 11;
+}
+#gesture-hint.active { display: block; }
+#gesture-hint h3 { margin: 0 0 6px 0; font-size: 13px; }
+#gesture-hint code {
+  background: rgba(255, 255, 255, 0.08);
+  padding: 1px 4px;
+  border-radius: 4px;
+  font-family: ui-monospace, "SF Mono", monospace;
+  font-size: 11px;
+}
+
+#toast {
+  position: absolute;
+  top: 80px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 20;
+  display: none;
+  padding: 10px 14px;
+  border-radius: 10px;
+  background: rgba(20, 22, 30, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  font-size: 13px;
+  max-width: 80vw;
+  text-align: center;
+  pointer-events: none;
+}
+#toast.show { display: block; }
+#toast.warn { border-color: #b45309; }
+#toast.error { border-color: #b91c1c; }
+
+@media (max-width: 600px) {
+  .hud-bar { gap: 6px; padding: 8px; }
+  .hud-stat { padding: 2px 6px; }
+  .hud-btn { padding: 6px 8px; font-size: 12px; }
+  #cv-layer { width: 60vw; bottom: 12px; right: 12px; }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,4 @@
+import { App } from './app/App';
+
+const app = new App();
+app.start();

--- a/src/render/OrbitCam.ts
+++ b/src/render/OrbitCam.ts
@@ -1,0 +1,12 @@
+import * as THREE from 'three';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+
+export function createOrbit(cam: THREE.Camera, dom: HTMLElement): OrbitControls {
+  const controls = new OrbitControls(cam, dom);
+  controls.enableDamping = true;
+  controls.dampingFactor = 0.08;
+  controls.enablePan = false;
+  controls.minDistance = 5;
+  controls.maxDistance = 18;
+  return controls;
+}

--- a/src/render/Renderer.ts
+++ b/src/render/Renderer.ts
@@ -1,0 +1,32 @@
+import * as THREE from 'three';
+
+export class Renderer {
+  readonly gl: THREE.WebGLRenderer;
+
+  constructor(canvas: HTMLCanvasElement) {
+    this.gl = new THREE.WebGLRenderer({
+      canvas,
+      antialias: true,
+      alpha: true,
+      powerPreference: 'high-performance',
+    });
+    this.gl.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    this.gl.outputColorSpace = THREE.SRGBColorSpace;
+    this.resize();
+    window.addEventListener('resize', () => this.resize());
+  }
+
+  resize(): void {
+    const w = window.innerWidth;
+    const h = window.innerHeight;
+    this.gl.setSize(w, h, false);
+  }
+
+  render(scene: THREE.Scene, camera: THREE.Camera): void {
+    this.gl.render(scene, camera);
+  }
+
+  get aspect(): number {
+    return window.innerWidth / window.innerHeight;
+  }
+}

--- a/src/render/Scene.ts
+++ b/src/render/Scene.ts
@@ -1,0 +1,26 @@
+import * as THREE from 'three';
+
+export function createScene(): THREE.Scene {
+  const scene = new THREE.Scene();
+  scene.background = new THREE.Color(0x0b0d12);
+
+  const ambient = new THREE.AmbientLight(0xffffff, 0.55);
+  scene.add(ambient);
+
+  const key = new THREE.DirectionalLight(0xffffff, 0.85);
+  key.position.set(5, 7, 6);
+  scene.add(key);
+
+  const fill = new THREE.DirectionalLight(0x99aaff, 0.35);
+  fill.position.set(-6, -2, -4);
+  scene.add(fill);
+
+  return scene;
+}
+
+export function createCamera(aspect: number): THREE.PerspectiveCamera {
+  const cam = new THREE.PerspectiveCamera(40, aspect, 0.1, 100);
+  cam.position.set(5.5, 5.0, 7.0);
+  cam.lookAt(0, 0, 0);
+  return cam;
+}

--- a/src/solver/Solver.ts
+++ b/src/solver/Solver.ts
@@ -1,0 +1,58 @@
+import type { Move } from '../types';
+import { bus } from '../app/events';
+
+export class Solver {
+  private worker: Worker;
+  private ready = false;
+  private readyPromise: Promise<void>;
+
+  constructor() {
+    this.worker = new Worker(new URL('./solver.worker.ts', import.meta.url), { type: 'module' });
+    this.readyPromise = new Promise((resolve, reject) => {
+      const onMsg = (e: MessageEvent) => {
+        const data = e.data;
+        if (data.type === 'ready') {
+          this.ready = true;
+          this.worker.removeEventListener('message', onMsg);
+          bus.emit('solver:ready', undefined);
+          resolve();
+        } else if (data.type === 'error') {
+          this.worker.removeEventListener('message', onMsg);
+          reject(new Error(data.message));
+        }
+      };
+      this.worker.addEventListener('message', onMsg);
+      this.worker.postMessage({ type: 'init' });
+    });
+  }
+
+  whenReady(): Promise<void> {
+    return this.readyPromise;
+  }
+
+  isReady(): boolean {
+    return this.ready;
+  }
+
+  async solve(facelets: string): Promise<Move[]> {
+    await this.readyPromise;
+    bus.emit('solver:solving', undefined);
+    return new Promise((resolve, reject) => {
+      const onMsg = (e: MessageEvent) => {
+        const data = e.data;
+        if (data.type === 'solution') {
+          this.worker.removeEventListener('message', onMsg);
+          const moves = data.moves as Move[];
+          bus.emit('solver:solution', { moves });
+          resolve(moves);
+        } else if (data.type === 'error') {
+          this.worker.removeEventListener('message', onMsg);
+          bus.emit('solver:error', { message: data.message });
+          reject(new Error(data.message));
+        }
+      };
+      this.worker.addEventListener('message', onMsg);
+      this.worker.postMessage({ type: 'solve', facelets });
+    });
+  }
+}

--- a/src/solver/solver.worker.ts
+++ b/src/solver/solver.worker.ts
@@ -1,0 +1,44 @@
+import Cube from 'cubejs';
+
+let initialized = false;
+
+interface InitMsg { type: 'init' }
+interface SolveMsg { type: 'solve'; facelets: string; maxDepth?: number }
+type InMsg = InitMsg | SolveMsg;
+
+interface ReadyMsg { type: 'ready' }
+interface SolutionMsg { type: 'solution'; moves: string[] }
+interface ErrorMsg { type: 'error'; message: string }
+type OutMsg = ReadyMsg | SolutionMsg | ErrorMsg;
+
+function ensureInit(): void {
+  if (initialized) return;
+  Cube.initSolver();
+  initialized = true;
+}
+
+self.onmessage = (e: MessageEvent<InMsg>) => {
+  const msg = e.data;
+  try {
+    if (msg.type === 'init') {
+      ensureInit();
+      const out: ReadyMsg = { type: 'ready' };
+      (self as unknown as Worker).postMessage(out);
+      return;
+    }
+    if (msg.type === 'solve') {
+      ensureInit();
+      const cube = Cube.fromString(msg.facelets);
+      const solution = cube.solve(msg.maxDepth ?? 22);
+      const moves = solution.split(/\s+/).filter(Boolean);
+      const out: SolutionMsg = { type: 'solution', moves };
+      (self as unknown as Worker).postMessage(out);
+      return;
+    }
+  } catch (err) {
+    const out: ErrorMsg = { type: 'error', message: (err as Error).message };
+    (self as unknown as Worker).postMessage(out);
+  }
+};
+
+export type { InMsg, OutMsg };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,27 @@
+export type Face = 'U' | 'R' | 'F' | 'D' | 'L' | 'B';
+export const FACES: Face[] = ['U', 'R', 'F', 'D', 'L', 'B'];
+
+export type Suffix = '' | "'" | '2';
+export type Move = `${Face}${Suffix}`;
+
+export type StickerColor = 'W' | 'Y' | 'R' | 'O' | 'G' | 'B';
+
+export type Mode = 'mouse' | 'gestures' | 'scan';
+
+export const FACE_COLOR: Record<Face, StickerColor> = {
+  U: 'W',
+  R: 'R',
+  F: 'G',
+  D: 'Y',
+  L: 'O',
+  B: 'B',
+};
+
+export const COLOR_HEX: Record<StickerColor, number> = {
+  W: 0xf5f5f5,
+  Y: 0xffd400,
+  R: 0xc62828,
+  O: 0xef6c00,
+  G: 0x2e7d32,
+  B: 0x1565c0,
+};

--- a/src/util/assert.ts
+++ b/src/util/assert.ts
@@ -1,0 +1,3 @@
+export function assert(cond: unknown, msg = 'assertion failed'): asserts cond {
+  if (!cond) throw new Error(msg);
+}

--- a/src/util/color.ts
+++ b/src/util/color.ts
@@ -1,0 +1,40 @@
+export interface RGB { r: number; g: number; b: number }
+export interface HSV { h: number; s: number; v: number }
+
+export function rgbToHsv({ r, g, b }: RGB): HSV {
+  const rn = r / 255;
+  const gn = g / 255;
+  const bn = b / 255;
+  const max = Math.max(rn, gn, bn);
+  const min = Math.min(rn, gn, bn);
+  const d = max - min;
+  let h = 0;
+  if (d !== 0) {
+    if (max === rn) h = ((gn - bn) / d) % 6;
+    else if (max === gn) h = (bn - rn) / d + 2;
+    else h = (rn - gn) / d + 4;
+    h *= 60;
+    if (h < 0) h += 360;
+  }
+  const s = max === 0 ? 0 : d / max;
+  return { h, s, v: max };
+}
+
+export function hueDist(a: number, b: number): number {
+  const d = Math.abs(a - b) % 360;
+  return d > 180 ? 360 - d : d;
+}
+
+export function median(values: number[]): number {
+  const s = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  return s.length % 2 === 0 ? (s[mid - 1] + s[mid]) / 2 : s[mid];
+}
+
+export function medianRgb(samples: RGB[]): RGB {
+  return {
+    r: median(samples.map((p) => p.r)),
+    g: median(samples.map((p) => p.g)),
+    b: median(samples.map((p) => p.b)),
+  };
+}

--- a/src/util/math.ts
+++ b/src/util/math.ts
@@ -1,0 +1,10 @@
+export const clamp = (v: number, a: number, b: number) => Math.min(b, Math.max(a, v));
+
+export const easeInOutCubic = (t: number) =>
+  t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
+
+export const TAU = Math.PI * 2;
+
+export function snapToLattice(v: number): number {
+  return Math.round(v);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable", "WebWorker"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "preserve",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  base: './',
+  optimizeDeps: {
+    exclude: ['@mediapipe/tasks-vision'],
+  },
+  worker: {
+    format: 'es',
+  },
+  build: {
+    target: 'es2022',
+  },
+});


### PR DESCRIPTION
Adds a full Vite + TypeScript + Three.js web app for a 3D 3x3 Rubik's cube playable with mouse, hand gestures, or by scanning a physical cube.

Architecture
- Render: three.js with OrbitControls, lit scene, 27 cubies built as THREE.Groups with sticker quads inset on each outward face.
- Cube state: CubeModel wraps cubejs (Kociemba) as the single logical source of truth; CubeView keeps cubies' visual transforms in sync via a transient pivot group, slerp-eased animations, and lattice snapping after each turn.
- Solver: Kociemba two-phase running in a Web Worker so the ~2 s table build doesn't block the main thread; HUD enables Solve once ready.
- HUD: timer, move counter, scramble, reset, solve, mode toggle, camera on/off; Spanish copy.
- CV gestures: MediaPipe HandLandmarker (Tasks Vision, GPU delegate). Two-handed vocabulary - left hand picks face (index up/right/down/left for U/R/D/L, palm-out for F, palm-in for B); right hand commits with thumb up/down or horizontal swipe; debounced 5 frames + 350 ms cooldown.
- CV scan: 3x3 grid overlay, walks the user through U R F D L B captures, median-of-medians per cell, center-anchored HSV classifier that adapts to lighting; sanity-checks color counts before passing facelets to the solver.

Build + assets
- Vite copies MediaPipe wasm runtime to public/wasm and downloads the hand_landmarker.task model on prebuild/predev via scripts/copy-...mjs.
- cubejs is wrapped via a local d.ts since the package ships no types.

Verified
- npm install OK, npx tsc --noEmit clean, vite build produces 656 kB main bundle (176 kB gzip) + 18 kB worker chunk; dev server serves all routes including /wasm and /models/hand_landmarker.task.