### PR TITLE
Add AR mode with hand-based cube rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Rubik 3D · Computer Vision Edition
 
-A minimalist 3D Rubik's cube that runs in the browser. Solve it with the
-mouse, with hand gestures captured by your webcam, or scan a real cube and
-let the built-in Kociemba solver do the rest.
+A minimalist 3D Rubik's cube that runs in the browser. Control it with the
+mouse or use your webcam to rotate the cube with hand tracking.
 
 > Vite · TypeScript · Three.js · MediaPipe · cubejs
 
@@ -39,41 +38,21 @@ lowercase = standard turn, uppercase = prime.
 | `f` / `F` | F / F' | `d` / `D` | D / D' |
 | `l` / `L` | L / L' | `b` / `B` | B / B' |
 
-### Hand gestures
-Two-handed vocabulary built on top of MediaPipe HandLandmarker (GPU
-delegate). The left hand selects a face, the right hand commits the
-direction.
+### AR Mode
+Uses MediaPipe HandLandmarker to track your hand via webcam. Move your
+**right hand** to rotate the cube:
 
-| Left hand | Face |
+| Hand position | Cube rotation |
 |---|---|
-| Index pointing up | **U** |
-| Index pointing right | **R** |
-| Index pointing down | **D** |
-| Index pointing left | **L** |
-| Open palm towards you | **F** |
-| Open palm away | **B** |
+| Hand to the left | Cube rotates left |
+| Hand to the right | Cube rotates right |
+| Hand up | Cube tilts up |
+| Hand down | Cube tilts down |
+| Hand at center | Cube faces forward |
 
-| Right hand | Direction |
-|---|---|
-| Thumb up · swipe right | CW (R, U, F…) |
-| Thumb down · swipe left | CCW (R', U', F'…) |
-| Closed fist (left hand) | Cancel selection |
-
-A gesture must hold for ~5 frames before it registers, with a 350 ms
-cooldown after each commit to avoid runaway turns.
-
-### Scan a real cube
-Show each of the six faces inside the 3×3 overlay in the order
-**U → R → F → D → L → B**. Press <kbd>Space</kbd> or the capture button.
-For each cell the sampler takes five small patches and uses the median to
-discard glare. The classifier identifies the six centres in HSV space and
-labels every other sticker by adapted distance to those references.
-
-When the scan completes the virtual cube redraws and the **Solve** button
-animates the Kociemba solution.
-
-> Scanning works best with even, frontal lighting. If the colour counts
-> don't add up the app restarts the scan and tells you which face failed.
+The rotation is smooth and position-based (not velocity-based), making it
+easy to control. When your hand leaves the frame, the cube smoothly returns
+to the center position.
 
 ---
 
@@ -82,7 +61,7 @@ animates the Kociemba solution.
 | Layer | Package |
 |---|---|
 | Build | Vite 5, TypeScript 5 (strict) |
-| 3D | `three` + `OrbitControls` + `RoundedBoxGeometry` |
+| 3D | `three` + `TrackballControls` + `RoundedBoxGeometry` |
 | CV | `@mediapipe/tasks-vision` (HandLandmarker, GPU) |
 | Solver | `cubejs` (Kociemba two-phase, in a Web Worker) |
 | Fonts | Inter · JetBrains Mono |
@@ -101,8 +80,8 @@ src/
 ├─ cv/
 │  ├─ Webcam.ts        getUserMedia + permissions
 │  ├─ HandTracker.ts   MediaPipe wrapper
-│  ├─ gestures/        Classifier + state-machine Mapper
-│  └─ scan/            GridOverlay · ColorSampler · ColorClassifier · ScanController
+│  ├─ HandOverlay.ts   Visual hand skeleton overlay
+│  └─ gestures/        GestureClassifier · HandRotation
 ├─ hud/            Hud · Timer · MoveCounter · hud.css
 ├─ util/           color · math · assert
 └─ types.ts
@@ -121,10 +100,6 @@ turn:
 3. When the animation ends, the cubie transforms are baked, positions
    snap to the integer lattice, and `model.applyMove(move)` advances the
    logical state. The model never changes mid-animation.
-
-After a scan, `model.setFromStickers(...)` replaces the logical state
-and `view.repaintFromFacelets(...)` re-skins each cubie at its home
-position, discarding any prior rotations.
 </details>
 
 ---
@@ -165,15 +140,6 @@ The browser needs HTTPS for `getUserMedia`.
   path of its own.
 - HandLandmarker runs at ~30 Hz (every other frame) to keep the render
   loop at 60 fps even on mid-range hardware.
-
----
-
-## Roadmap
-
-- Optional dark theme.
-- WebGPU renderer when stable.
-- One-handed gesture mode for mobile.
-- Local persistence of times and scrambles.
 
 ---
 

--- a/src/app/App.ts
+++ b/src/app/App.ts
@@ -11,9 +11,8 @@ import { Hud } from '../hud/Hud';
 import { Webcam } from '../cv/Webcam';
 import { HandTracker } from '../cv/HandTracker';
 import { GestureClassifier } from '../cv/gestures/GestureClassifier';
-import { GestureMapper } from '../cv/gestures/GestureMapper';
-import { GridOverlay } from '../cv/scan/GridOverlay';
-import { ScanController } from '../cv/scan/ScanController';
+import { HandRotation } from '../cv/gestures/HandRotation';
+import { HandOverlay } from '../cv/HandOverlay';
 import { bus } from './events';
 import type { Mode, Move } from '../types';
 import { expandHalfTurns } from '../cube/Notation';
@@ -32,9 +31,9 @@ export class App {
   private webcam: Webcam;
   private handTracker: HandTracker;
   private gestureClassifier: GestureClassifier;
-  private gestureMapper: GestureMapper;
-  private gridOverlay: GridOverlay;
-  private scanCtl: ScanController;
+  private handRotation: HandRotation;
+  private handOverlay: HandOverlay;
+  private contactShadow: THREE.Mesh | null = null;
 
   private mode: Mode = 'mouse';
   private cvFrame = 0;
@@ -64,8 +63,6 @@ export class App {
       onSolve: () => this.solve(),
       onModeChange: (m) => this.setMode(m),
       onCameraToggle: () => this.toggleCamera(),
-      onScanCapture: () => this.scanCtl.capture(),
-      onScanRestart: () => this.scanCtl.start(),
     });
     this.hud.setMode('mouse');
 
@@ -74,14 +71,17 @@ export class App {
     this.webcam = new Webcam(video);
     this.handTracker = new HandTracker();
     this.gestureClassifier = new GestureClassifier();
-    this.gestureMapper = new GestureMapper({
-      onMove: (m) => this.engine.queueMove(m),
+    this.handRotation = new HandRotation(this.view);
+    this.handOverlay = new HandOverlay(overlay);
+
+    // Find contact shadow in scene for AR mode visibility toggle
+    this.scene.traverse((obj) => {
+      if (obj instanceof THREE.Mesh && obj.name === 'contactShadow') {
+        this.contactShadow = obj;
+      }
     });
-    this.gridOverlay = new GridOverlay(overlay);
-    this.scanCtl = new ScanController(this.webcam, this.gridOverlay, (res) => this.applyScanResult(res));
 
     this.bindKeys();
-    this.bindBus();
 
     window.addEventListener('resize', () => {
       this.camera.aspect = this.renderer.aspect;
@@ -95,18 +95,50 @@ export class App {
 
   private loop = (): void => {
     requestAnimationFrame(this.loop);
-    this.orbit.update();
 
-    if (this.mode === 'gestures' && this.webcam.isOn() && this.handTracker.isReady()) {
+    // Only update orbit controls in non-AR modes
+    if (this.mode !== 'ar') {
+      this.orbit.update();
+    }
+
+    if (this.mode === 'ar' && this.webcam.isOn() && this.handTracker.isReady()) {
       this.cvFrame += 1;
       // Throttle hand detection to ~30 Hz on 60 fps render.
       if (this.cvFrame % 2 === 0) {
         const result = this.handTracker.detect(this.webcam.video, performance.now());
+        if (this.cvFrame % 60 === 0) {
+          console.log('[AR] Detection result:', result?.landmarks?.length ?? 0, 'hands');
+        }
         if (result) {
           const frame = this.gestureClassifier.classify(result, performance.now());
-          this.gestureMapper.process(frame);
+          // Build landmarks map for direct manipulation
+          const landmarksMap = new Map<'Left' | 'Right', import('../cv/gestures/types').Landmark[]>();
+          const allLandmarks: import('../cv/gestures/types').Landmark[][] = [];
+          const isPinching: boolean[] = [];
+
+          if (result.landmarks && result.handedness) {
+            for (let i = 0; i < result.landmarks.length; i++) {
+              const hand = result.handedness[i]?.[0]?.categoryName as 'Left' | 'Right' | undefined;
+              const lm = result.landmarks[i] as import('../cv/gestures/types').Landmark[];
+              if (hand) {
+                landmarksMap.set(hand, lm);
+              }
+              allLandmarks.push(lm);
+              // Check if this hand is pinching
+              const shape = frame.hands.find(h => h.hand === hand);
+              isPinching.push(shape?.shape === 'pinch');
+            }
+          }
+
+          // Draw hand overlay
+          this.handOverlay.draw(allLandmarks, isPinching);
+
+          // Rotate cube with right hand (open palm resets to front)
+          this.handRotation.processFrame(landmarksMap, frame.hands);
         }
       }
+    } else if (this.mode !== 'ar') {
+      this.handOverlay.clear();
     }
 
     this.renderer.render(this.scene, this.camera);
@@ -123,24 +155,10 @@ export class App {
     };
     window.addEventListener('keydown', (e) => {
       if (e.target && (e.target as HTMLElement).tagName === 'INPUT') return;
-      if (e.code === 'Space') {
-        if (this.mode === 'scan') {
-          e.preventDefault();
-          this.scanCtl.capture();
-        }
-        return;
-      }
       const move = map[e.key];
       if (move) {
         this.engine.queueMove(move);
       }
-    });
-  }
-
-  private bindBus(): void {
-    bus.on('scan:progress', ({ faceIndex, total }) => {
-      const label = this.scanCtl.faceLabel();
-      this.hud.setScanProgress(faceIndex, total, `Mostrando: <b>${label}</b>. Pulsa <kbd>Espacio</kbd> o el botón.`);
     });
   }
 
@@ -184,15 +202,27 @@ export class App {
 
   private async setMode(mode: Mode): Promise<void> {
     if (this.mode === mode) return;
+    const prevMode = this.mode;
     this.mode = mode;
     this.hud.setMode(mode);
     const cvLayer = document.getElementById('cv-layer')!;
-    cvLayer.classList.toggle('active', mode !== 'mouse');
-    cvLayer.classList.toggle('scan-mode', mode === 'scan');
+    cvLayer.classList.toggle('active', mode === 'ar');
+    cvLayer.classList.toggle('ar-mode', mode === 'ar');
     bus.emit('mode:changed', { mode });
 
+    // Handle AR mode specifics
+    if (mode === 'ar') {
+      // Hide contact shadow in AR mode
+      if (this.contactShadow) this.contactShadow.visible = false;
+      // Disable orbit controls
+      this.orbit.enabled = false;
+    } else if (prevMode === 'ar') {
+      // Restore from AR mode
+      if (this.contactShadow) this.contactShadow.visible = true;
+      this.orbit.enabled = true;
+    }
+
     if (mode === 'mouse') {
-      this.gridOverlay.clear();
       return;
     }
 
@@ -204,21 +234,20 @@ export class App {
       }
     }
 
-    if (mode === 'gestures') {
+    if (mode === 'ar') {
       try {
+        console.log('[AR] Initializing hand tracker...');
         await this.handTracker.init();
-      } catch {
-        /* error already toasted */
+        console.log('[AR] Hand tracker ready:', this.handTracker.isReady());
+      } catch (e) {
+        console.error('[AR] Hand tracker init failed:', e);
       }
-    } else if (mode === 'scan') {
-      this.scanCtl.start();
     }
   }
 
   private async toggleCamera(): Promise<void> {
     if (this.webcam.isOn()) {
       this.webcam.stop();
-      this.gridOverlay.clear();
       const cvLayer = document.getElementById('cv-layer')!;
       cvLayer.classList.remove('active');
     } else {
@@ -228,18 +257,6 @@ export class App {
       } catch {
         /* error already toasted */
       }
-    }
-  }
-
-  private applyScanResult(res: { stickers54: import('../types').StickerColor[] }): void {
-    try {
-      this.model.setFromStickers(res.stickers54);
-      this.view.repaintFromFacelets(this.model.getFacelets());
-      // re-attach pivot (was inside view.group; group rebuilt? No — repaint reuses cubies)
-      bus.emit('toast', { message: 'Escaneo completado, listo para resolver', kind: 'info' });
-      this.setMode('mouse');
-    } catch (err) {
-      bus.emit('toast', { message: `Estado inválido: ${(err as Error).message}`, kind: 'error' });
     }
   }
 }

--- a/src/cv/HandOverlay.ts
+++ b/src/cv/HandOverlay.ts
@@ -1,0 +1,106 @@
+import type { Landmark } from './gestures/types';
+
+// MediaPipe hand connections for drawing skeleton
+const HAND_CONNECTIONS: [number, number][] = [
+  [0, 1], [1, 2], [2, 3], [3, 4],       // thumb
+  [0, 5], [5, 6], [6, 7], [7, 8],       // index
+  [0, 9], [9, 10], [10, 11], [11, 12],  // middle
+  [0, 13], [13, 14], [14, 15], [15, 16], // ring
+  [0, 17], [17, 18], [18, 19], [19, 20], // pinky
+  [5, 9], [9, 13], [13, 17],            // palm
+];
+
+export class HandOverlay {
+  private ctx: CanvasRenderingContext2D;
+
+  constructor(private canvas: HTMLCanvasElement) {
+    this.ctx = canvas.getContext('2d')!;
+  }
+
+  draw(handsLandmarks: Landmark[][], isPinching: boolean[] = []): void {
+    const video = this.canvas.parentElement?.querySelector('video');
+    if (video) {
+      this.canvas.width = video.videoWidth || this.canvas.clientWidth;
+      this.canvas.height = video.videoHeight || this.canvas.clientHeight;
+    }
+
+    this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+
+    for (let h = 0; h < handsLandmarks.length; h++) {
+      const landmarks = handsLandmarks[h];
+      const pinching = isPinching[h] ?? false;
+      this.drawHand(landmarks, pinching);
+    }
+  }
+
+  private drawHand(landmarks: Landmark[], pinching: boolean): void {
+    const w = this.canvas.width;
+    const h = this.canvas.height;
+
+    // Draw connections
+    this.ctx.strokeStyle = pinching ? '#22c55e' : '#3b82f6';
+    this.ctx.lineWidth = 3;
+    this.ctx.lineCap = 'round';
+
+    for (const [i, j] of HAND_CONNECTIONS) {
+      const a = landmarks[i];
+      const b = landmarks[j];
+      // Video is mirrored, so flip x
+      const ax = (1 - a.x) * w;
+      const ay = a.y * h;
+      const bx = (1 - b.x) * w;
+      const by = b.y * h;
+
+      this.ctx.beginPath();
+      this.ctx.moveTo(ax, ay);
+      this.ctx.lineTo(bx, by);
+      this.ctx.stroke();
+    }
+
+    // Draw landmarks
+    for (let i = 0; i < landmarks.length; i++) {
+      const lm = landmarks[i];
+      const x = (1 - lm.x) * w;
+      const y = lm.y * h;
+
+      // Highlight thumb tip (4) and index tip (8) when pinching
+      const isFingerTip = i === 4 || i === 8;
+
+      this.ctx.beginPath();
+      this.ctx.arc(x, y, isFingerTip ? 8 : 4, 0, Math.PI * 2);
+
+      if (pinching && isFingerTip) {
+        this.ctx.fillStyle = '#22c55e';
+      } else if (isFingerTip) {
+        this.ctx.fillStyle = '#ef4444';
+      } else {
+        this.ctx.fillStyle = '#fff';
+      }
+      this.ctx.fill();
+
+      this.ctx.strokeStyle = '#000';
+      this.ctx.lineWidth = 1;
+      this.ctx.stroke();
+    }
+
+    // Draw pinch indicator
+    if (pinching) {
+      const thumb = landmarks[4];
+      const index = landmarks[8];
+      const cx = (1 - (thumb.x + index.x) / 2) * w;
+      const cy = ((thumb.y + index.y) / 2) * h;
+
+      this.ctx.beginPath();
+      this.ctx.arc(cx, cy, 15, 0, Math.PI * 2);
+      this.ctx.fillStyle = 'rgba(34, 197, 94, 0.4)';
+      this.ctx.fill();
+      this.ctx.strokeStyle = '#22c55e';
+      this.ctx.lineWidth = 3;
+      this.ctx.stroke();
+    }
+  }
+
+  clear(): void {
+    this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+  }
+}

--- a/src/cv/gestures/DirectManipulation.ts
+++ b/src/cv/gestures/DirectManipulation.ts
@@ -1,0 +1,379 @@
+import * as THREE from 'three';
+import type { Face, Move } from '../../types';
+import type { CubeView, Cubie } from '../../cube/CubeView';
+import type { MoveEngine } from '../../cube/MoveEngine';
+import type { HandShape, Handedness, Landmark } from './types';
+
+type GrabPhase = 'IDLE' | 'PINCHING' | 'DRAGGING' | 'RELEASING';
+
+interface LayerSelection {
+  face: Face;
+  axis: THREE.Vector3;
+  cubies: Cubie[];
+}
+
+interface GrabState {
+  hand: Handedness;
+  startNDC: THREE.Vector2;
+  layer: LayerSelection;
+  currentAngle: number;
+}
+
+const FACE_AXIS: Record<Face, THREE.Vector3> = {
+  U: new THREE.Vector3(0, 1, 0),
+  D: new THREE.Vector3(0, -1, 0),
+  R: new THREE.Vector3(1, 0, 0),
+  L: new THREE.Vector3(-1, 0, 0),
+  F: new THREE.Vector3(0, 0, 1),
+  B: new THREE.Vector3(0, 0, -1),
+};
+
+const AXIS_TO_FACES: [THREE.Vector3, Face, Face][] = [
+  [new THREE.Vector3(1, 0, 0), 'R', 'L'],
+  [new THREE.Vector3(0, 1, 0), 'U', 'D'],
+  [new THREE.Vector3(0, 0, 1), 'F', 'B'],
+];
+
+const DRAG_THRESHOLD = 0.03;
+const ROTATION_SENSITIVITY = 3.5;
+
+export class DirectManipulation {
+  private raycaster = new THREE.Raycaster();
+  private phase: GrabPhase = 'IDLE';
+  private grabState: GrabState | null = null;
+
+  constructor(
+    private camera: THREE.PerspectiveCamera,
+    private view: CubeView,
+    private engine: MoveEngine,
+    private pivot: THREE.Group,
+  ) {}
+
+  processFrame(hands: HandShape[], landmarks: Map<Handedness, Landmark[]>): void {
+    const pinchingHand = hands.find((h) => h.shape === 'pinch');
+
+    switch (this.phase) {
+      case 'IDLE':
+        if (pinchingHand) {
+          const lm = landmarks.get(pinchingHand.hand);
+          if (lm) this.tryStartGrab(pinchingHand.hand, lm);
+        }
+        break;
+
+      case 'PINCHING':
+        if (!pinchingHand || (this.grabState && pinchingHand.hand !== this.grabState.hand)) {
+          this.cancelGrab();
+        } else if (this.grabState) {
+          const lm = landmarks.get(this.grabState.hand);
+          if (lm) this.checkDragStart(lm);
+        }
+        break;
+
+      case 'DRAGGING':
+        if (!pinchingHand || (this.grabState && pinchingHand.hand !== this.grabState.hand)) {
+          this.releaseGrab();
+        } else if (this.grabState) {
+          const lm = landmarks.get(this.grabState.hand);
+          if (lm) this.updateDrag(lm);
+        }
+        break;
+
+      case 'RELEASING':
+        // Waiting for animation to complete
+        break;
+    }
+  }
+
+  private toNDC(landmark: Landmark): THREE.Vector2 {
+    // Video is mirrored via CSS, flip x for screen mapping
+    const screenX = 1 - landmark.x;
+    const screenY = landmark.y;
+    const ndcX = screenX * 2 - 1;
+    const ndcY = -(screenY * 2 - 1);
+    return new THREE.Vector2(ndcX, ndcY);
+  }
+
+  private getPinchPoint(landmarks: Landmark[]): Landmark {
+    const thumb = landmarks[4];
+    const index = landmarks[8];
+    return {
+      x: (thumb.x + index.x) / 2,
+      y: (thumb.y + index.y) / 2,
+      z: (thumb.z + index.z) / 2,
+    };
+  }
+
+  private tryStartGrab(hand: Handedness, landmarks: Landmark[]): void {
+    const pinchPoint = this.getPinchPoint(landmarks);
+    const ndc = this.toNDC(pinchPoint);
+
+    const hit = this.raycastToCube(ndc.x, ndc.y);
+    if (!hit) return;
+
+    this.phase = 'PINCHING';
+    this.grabState = {
+      hand,
+      startNDC: ndc.clone(),
+      layer: null!,
+      currentAngle: 0,
+    };
+  }
+
+  private checkDragStart(landmarks: Landmark[]): void {
+    if (!this.grabState) return;
+
+    const pinchPoint = this.getPinchPoint(landmarks);
+    const ndc = this.toNDC(pinchPoint);
+    const delta = ndc.clone().sub(this.grabState.startNDC);
+
+    if (delta.length() < DRAG_THRESHOLD) return;
+
+    // Determine layer based on hit and drag direction
+    const hit = this.raycastToCube(this.grabState.startNDC.x, this.grabState.startNDC.y);
+    if (!hit) {
+      this.cancelGrab();
+      return;
+    }
+
+    const layer = this.determineLayer(hit, delta);
+    if (!layer) {
+      this.cancelGrab();
+      return;
+    }
+
+    this.grabState.layer = layer;
+    this.phase = 'DRAGGING';
+
+    // Attach layer cubies to pivot
+    for (const c of layer.cubies) this.pivot.attach(c.mesh);
+    this.pivot.quaternion.identity();
+  }
+
+  private raycastToCube(ndcX: number, ndcY: number): THREE.Intersection | null {
+    this.raycaster.setFromCamera(new THREE.Vector2(ndcX, ndcY), this.camera);
+
+    const meshes: THREE.Object3D[] = [];
+    for (const cubie of this.view.getAllCubies()) {
+      cubie.mesh.traverse((obj) => {
+        if (obj instanceof THREE.Mesh) meshes.push(obj);
+      });
+    }
+
+    const intersects = this.raycaster.intersectObjects(meshes, false);
+    return intersects.length > 0 ? intersects[0] : null;
+  }
+
+  private determineLayer(hit: THREE.Intersection, dragDir: THREE.Vector2): LayerSelection | null {
+    const hitNormal = hit.face?.normal;
+    if (!hitNormal) return null;
+
+    // Transform normal to world space
+    const worldNormal = hitNormal.clone().transformDirection(hit.object.matrixWorld).normalize();
+
+    // Find which face this normal corresponds to
+    let hitFace: Face | null = null;
+    let maxDot = -Infinity;
+    for (const [face, axis] of Object.entries(FACE_AXIS) as [Face, THREE.Vector3][]) {
+      const dot = worldNormal.dot(axis);
+      if (dot > maxDot) {
+        maxDot = dot;
+        hitFace = face;
+      }
+    }
+
+    if (!hitFace || maxDot < 0.8) return null;
+
+    // Get the cubie's position
+    let cubie: Cubie | null = null;
+    let parent = hit.object.parent;
+    while (parent) {
+      for (const c of this.view.getAllCubies()) {
+        if (c.mesh === parent) {
+          cubie = c;
+          break;
+        }
+      }
+      if (cubie) break;
+      parent = parent.parent;
+    }
+
+    if (!cubie) return null;
+
+    const cubiePos = cubie.mesh.position.clone();
+
+    // Determine rotation axis based on drag direction
+    // Project drag direction to 3D: camera right is (1,0,0) in screen, up is (0,1,0)
+    const cameraRight = new THREE.Vector3(1, 0, 0).applyQuaternion(this.camera.quaternion);
+    const cameraUp = new THREE.Vector3(0, 1, 0).applyQuaternion(this.camera.quaternion);
+
+    // Drag in 3D space
+    const drag3D = cameraRight.clone().multiplyScalar(dragDir.x).add(cameraUp.clone().multiplyScalar(dragDir.y));
+
+    // Rotation axis is perpendicular to both face normal and drag direction
+    const faceAxisVec = FACE_AXIS[hitFace].clone();
+    const rotationAxis = drag3D.clone().cross(faceAxisVec).normalize();
+
+    // Find which standard axis this is closest to
+    let bestAxisIdx = -1;
+    let bestDot = -Infinity;
+    for (let i = 0; i < AXIS_TO_FACES.length; i++) {
+      const dot = Math.abs(rotationAxis.dot(AXIS_TO_FACES[i][0]));
+      if (dot > bestDot) {
+        bestDot = dot;
+        bestAxisIdx = i;
+      }
+    }
+
+    if (bestAxisIdx < 0 || bestDot < 0.5) return null;
+
+    const [standardAxis, posFace, negFace] = AXIS_TO_FACES[bestAxisIdx];
+    const sign = rotationAxis.dot(standardAxis) > 0 ? 1 : -1;
+    const actualAxis = standardAxis.clone().multiplyScalar(sign);
+
+    // Determine which layer based on cubie position
+    const axisIdx = standardAxis.x !== 0 ? 0 : standardAxis.y !== 0 ? 1 : 2;
+    const coord = axisIdx === 0 ? cubiePos.x : axisIdx === 1 ? cubiePos.y : cubiePos.z;
+    const roundedCoord = Math.round(coord);
+
+    // Map coordinate to face
+    let face: Face;
+    if (roundedCoord === 1) {
+      face = posFace;
+    } else if (roundedCoord === -1) {
+      face = negFace;
+    } else {
+      // Middle layer - use one of the adjacent faces
+      // For middle slices, we'll just use the positive face
+      face = posFace;
+    }
+
+    // Only support outer layers for now (not middle slices)
+    if (roundedCoord === 0) return null;
+
+    const cubies = this.view.getLayerCubies(face);
+    return { face, axis: actualAxis, cubies };
+  }
+
+  private updateDrag(landmarks: Landmark[]): void {
+    if (!this.grabState || !this.grabState.layer) return;
+
+    const pinchPoint = this.getPinchPoint(landmarks);
+    const ndc = this.toNDC(pinchPoint);
+    const delta = ndc.clone().sub(this.grabState.startNDC);
+
+    // Convert drag delta to rotation angle
+    const angle = delta.length() * ROTATION_SENSITIVITY;
+
+    // Determine rotation direction based on drag direction relative to axis
+    const cameraRight = new THREE.Vector3(1, 0, 0).applyQuaternion(this.camera.quaternion);
+    const cameraUp = new THREE.Vector3(0, 1, 0).applyQuaternion(this.camera.quaternion);
+    const drag3D = cameraRight.clone().multiplyScalar(delta.x).add(cameraUp.clone().multiplyScalar(delta.y));
+
+    // Cross product to determine rotation direction
+    const faceAxis = FACE_AXIS[this.grabState.layer.face];
+    const cross = drag3D.clone().cross(faceAxis);
+    const direction = cross.dot(this.grabState.layer.axis) > 0 ? 1 : -1;
+
+    this.grabState.currentAngle = angle * direction;
+
+    // Apply rotation to pivot
+    this.pivot.quaternion.setFromAxisAngle(this.grabState.layer.axis, this.grabState.currentAngle);
+  }
+
+  private cancelGrab(): void {
+    if (this.grabState?.layer) {
+      // Reparent cubies back without committing
+      for (const c of this.grabState.layer.cubies) {
+        this.view.group.attach(c.mesh);
+      }
+      this.pivot.quaternion.identity();
+    }
+    this.grabState = null;
+    this.phase = 'IDLE';
+  }
+
+  private async releaseGrab(): Promise<void> {
+    if (!this.grabState || !this.grabState.layer) {
+      this.phase = 'IDLE';
+      return;
+    }
+
+    this.phase = 'RELEASING';
+
+    const angle = this.grabState.currentAngle;
+    const face = this.grabState.layer.face;
+    const cubies = this.grabState.layer.cubies;
+    const axis = this.grabState.layer.axis;
+
+    // Determine snap target
+    const absAngle = Math.abs(angle);
+    let targetAngle: number;
+    let move: Move | null = null;
+
+    if (absAngle < Math.PI / 4) {
+      // Less than 45 degrees - cancel
+      targetAngle = 0;
+    } else if (absAngle < (3 * Math.PI) / 4) {
+      // 45-135 degrees - single turn
+      targetAngle = angle > 0 ? Math.PI / 2 : -Math.PI / 2;
+      const suffix = angle > 0 ? "'" : '';
+      move = `${face}${suffix}` as Move;
+    } else {
+      // 135+ degrees - double turn
+      targetAngle = angle > 0 ? Math.PI : -Math.PI;
+      move = `${face}2` as Move;
+    }
+
+    // Animate to target
+    await this.animateSnap(axis, angle, targetAngle, cubies);
+
+    // Reparent cubies back
+    for (const c of cubies) {
+      this.view.group.attach(c.mesh);
+      c.mesh.position.x = Math.round(c.mesh.position.x);
+      c.mesh.position.y = Math.round(c.mesh.position.y);
+      c.mesh.position.z = Math.round(c.mesh.position.z);
+    }
+    this.pivot.quaternion.identity();
+    this.view.snapAll();
+
+    // Commit the move if applicable
+    if (move && !this.engine.isBusy()) {
+      // We already rotated visually, just update the model
+      this.engine.setSilent();
+      this.engine.queueMove(move);
+    }
+
+    this.grabState = null;
+    this.phase = 'IDLE';
+  }
+
+  private animateSnap(
+    axis: THREE.Vector3,
+    fromAngle: number,
+    toAngle: number,
+    _cubies: Cubie[],
+  ): Promise<void> {
+    return new Promise((resolve) => {
+      const duration = 150;
+      const start = performance.now();
+
+      const tick = () => {
+        const elapsed = performance.now() - start;
+        const t = Math.min(1, elapsed / duration);
+        const eased = t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2; // easeInOutQuad
+
+        const currentAngle = fromAngle + (toAngle - fromAngle) * eased;
+        this.pivot.quaternion.setFromAxisAngle(axis, currentAngle);
+
+        if (t < 1) {
+          requestAnimationFrame(tick);
+        } else {
+          resolve();
+        }
+      };
+
+      tick();
+    });
+  }
+}

--- a/src/cv/gestures/GestureClassifier.ts
+++ b/src/cv/gestures/GestureClassifier.ts
@@ -5,6 +5,7 @@ const FINGER_TIPS = [4, 8, 12, 16, 20];
 const FINGER_PIPS = [3, 6, 10, 14, 18];
 const FINGER_MCPS = [2, 5, 9, 13, 17];
 const WRIST = 0;
+const MIDDLE_MCP = 9;
 
 function dist(a: Landmark, b: Landmark): number {
   const dx = a.x - b.x;
@@ -24,10 +25,26 @@ function isFingerExtended(landmarks: Landmark[], finger: number): boolean {
   return tipDist > pipDist && pipDist > mcpDist * 0.95;
 }
 
+function isPinching(landmarks: Landmark[]): boolean {
+  const thumbTip = landmarks[4];
+  const indexTip = landmarks[8];
+  const wrist = landmarks[WRIST];
+  const middleMcp = landmarks[MIDDLE_MCP];
+  const handSize = dist(wrist, middleMcp);
+  const pinchDist = dist(thumbTip, indexTip) / handSize;
+  return pinchDist < 0.18;
+}
+
 function classify(landmarks: Landmark[], hand: Handedness): HandShape {
+  const wrist = landmarks[WRIST];
+
+  // Check pinch first (thumb and index touching)
+  if (isPinching(landmarks)) {
+    return { hand, shape: 'pinch', wrist };
+  }
+
   const ext = [0, 1, 2, 3, 4].map((f) => isFingerExtended(landmarks, f));
   const [thumbExt, indexExt, middleExt, ringExt, pinkyExt] = ext;
-  const wrist = landmarks[WRIST];
   const indexTip = landmarks[8];
   const indexMcp = landmarks[5];
 

--- a/src/cv/gestures/HandRotation.ts
+++ b/src/cv/gestures/HandRotation.ts
@@ -1,0 +1,80 @@
+import type { CubeView } from '../../cube/CubeView';
+import type { Landmark, Handedness, HandShape } from './types';
+
+// Discrete rotation angles for each zone
+const FRONT = 0;
+const LEFT = Math.PI / 2;      // 90 degrees
+const RIGHT = -Math.PI / 2;    // -90 degrees
+const UP = -Math.PI / 4;       // -45 degrees tilt
+const DOWN = Math.PI / 4;      // 45 degrees tilt
+
+// Zone thresholds (normalized 0-1 coordinates)
+const LEFT_ZONE = 0.35;
+const RIGHT_ZONE = 0.65;
+const UP_ZONE = 0.35;
+const DOWN_ZONE = 0.65;
+
+export class HandRotation {
+  private targetY = 0;
+  private targetX = 0;
+  private currentY = 0;
+  private currentX = 0;
+
+  constructor(private view: CubeView) {}
+
+  processFrame(landmarks: Map<Handedness, Landmark[]>, hands?: HandShape[]): void {
+    const rightHand = landmarks.get('Right');
+
+    // Check if right hand is open palm → reset to front view
+    const rightHandShape = hands?.find(h => h.hand === 'Right');
+    const isOpenPalm = rightHandShape?.shape === 'palmIn' || rightHandShape?.shape === 'palmOut';
+
+    if (!rightHand || isOpenPalm) {
+      // Return to front when hand is not visible or open palm
+      this.targetX = 0;
+      this.targetY = 0;
+    } else {
+      // Use wrist position (landmark 0) for tracking
+      const wrist = rightHand[0];
+      // Mirror X because video is flipped
+      const x = 1 - wrist.x;
+      const y = wrist.y;
+
+      // Determine horizontal zone (left, center, right)
+      if (x < LEFT_ZONE) {
+        this.targetY = LEFT;
+      } else if (x > RIGHT_ZONE) {
+        this.targetY = RIGHT;
+      } else {
+        this.targetY = FRONT;
+      }
+
+      // Determine vertical zone (up, center, down)
+      if (y < UP_ZONE) {
+        this.targetX = UP;
+      } else if (y > DOWN_ZONE) {
+        this.targetX = DOWN;
+      } else {
+        this.targetX = 0;
+      }
+    }
+
+    // Smooth interpolation to target (easing)
+    const smoothing = 0.12;
+    this.currentY += (this.targetY - this.currentY) * smoothing;
+    this.currentX += (this.targetX - this.currentX) * smoothing;
+
+    // Apply rotation
+    this.view.group.rotation.y = this.currentY;
+    this.view.group.rotation.x = this.currentX;
+  }
+
+  reset(): void {
+    this.targetX = 0;
+    this.targetY = 0;
+    this.currentX = 0;
+    this.currentY = 0;
+    this.view.group.rotation.x = 0;
+    this.view.group.rotation.y = 0;
+  }
+}

--- a/src/cv/gestures/types.ts
+++ b/src/cv/gestures/types.ts
@@ -8,7 +8,7 @@ export type FingerCurl = 'extended' | 'curled';
 
 export interface HandShape {
   hand: Handedness;
-  shape: 'fist' | 'open' | 'pointUp' | 'pointDown' | 'pointLeft' | 'pointRight' | 'thumbUp' | 'thumbDown' | 'palmIn' | 'palmOut' | 'unknown';
+  shape: 'fist' | 'open' | 'pointUp' | 'pointDown' | 'pointLeft' | 'pointRight' | 'thumbUp' | 'thumbDown' | 'palmIn' | 'palmOut' | 'pinch' | 'unknown';
   wrist: Landmark;
 }
 

--- a/src/hud/Hud.ts
+++ b/src/hud/Hud.ts
@@ -9,8 +9,6 @@ export interface HudHandlers {
   onSolve: () => void;
   onModeChange: (m: Mode) => void;
   onCameraToggle: () => void;
-  onScanCapture: () => void;
-  onScanRestart: () => void;
 }
 
 export class Hud {
@@ -20,8 +18,7 @@ export class Hud {
   private cameraBtn: HTMLButtonElement;
   private solveBtn: HTMLButtonElement;
   private scrambleBtn: HTMLButtonElement;
-  private scanPanel: HTMLDivElement;
-  private gestureHint: HTMLDivElement;
+  private arHint: HTMLDivElement;
   private toastEl: HTMLDivElement;
   private toastTimeout: number | null = null;
 
@@ -36,8 +33,7 @@ export class Hud {
       <button class="hud-btn primary" id="hud-solve">Resolver</button>
       <div class="hud-mode" id="hud-mode">
         <button data-mode="mouse" class="active">Ratón</button>
-        <button data-mode="gestures">Gestos</button>
-        <button data-mode="scan">Escanear</button>
+        <button data-mode="ar">AR</button>
       </div>
       <button class="hud-btn" id="hud-camera">Cámara on</button>
     `;
@@ -57,42 +53,25 @@ export class Hud {
 
     this.modeButtons = {
       mouse: bar.querySelector<HTMLButtonElement>('button[data-mode="mouse"]')!,
-      gestures: bar.querySelector<HTMLButtonElement>('button[data-mode="gestures"]')!,
-      scan: bar.querySelector<HTMLButtonElement>('button[data-mode="scan"]')!,
-    };
-    for (const m of ['mouse', 'gestures', 'scan'] as Mode[]) {
+      ar: bar.querySelector<HTMLButtonElement>('button[data-mode="ar"]')!,
+    } as Record<Mode, HTMLButtonElement>;
+    for (const m of ['mouse', 'ar'] as Mode[]) {
       this.modeButtons[m].addEventListener('click', () => handlers.onModeChange(m));
     }
 
     this.cameraBtn = bar.querySelector<HTMLButtonElement>('#hud-camera')!;
     this.cameraBtn.addEventListener('click', handlers.onCameraToggle);
 
-    this.scanPanel = document.createElement('div');
-    this.scanPanel.id = 'scan-panel';
-    this.scanPanel.innerHTML = `
-      <h3>Escaneo del cubo</h3>
-      <div class="progress" id="scan-progress"></div>
-      <p id="scan-msg">Muestra la cara <b>U</b> (blanca) hacia la cámara y pulsa <kbd>Espacio</kbd> o el botón.</p>
-      <div class="actions">
-        <button class="hud-btn primary" id="scan-capture">Capturar</button>
-        <button class="hud-btn" id="scan-restart">Reiniciar</button>
-      </div>
-    `;
-    document.getElementById('hud-root')!.appendChild(this.scanPanel);
-    this.scanPanel.querySelector<HTMLButtonElement>('#scan-capture')!.addEventListener('click', handlers.onScanCapture);
-    this.scanPanel.querySelector<HTMLButtonElement>('#scan-restart')!.addEventListener('click', handlers.onScanRestart);
-
-    this.gestureHint = document.createElement('div');
-    this.gestureHint.id = 'gesture-hint';
-    this.gestureHint.innerHTML = `
-      <h3>Modo gestos (dos manos)</h3>
+    this.arHint = document.createElement('div');
+    this.arHint.id = 'gesture-hint';
+    this.arHint.innerHTML = `
+      <h3>Modo AR</h3>
       <p>
-        <b>Izquierda</b> elige cara: índice ↑ <code>U</code>, → <code>R</code>, ↓ <code>D</code>, ← <code>L</code>;
-        palma hacia ti <code>F</code>, palma fuera <code>B</code>.<br/>
-        <b>Derecha</b> confirma: 👍 / swipe der → <b>CW</b>; 👎 / swipe izq → <b>CCW</b>.
+        Mueve tu <b>mano derecha</b> para rotar el cubo.<br/>
+        <b>Mano abierta</b> → vista frontal.
       </p>
     `;
-    document.getElementById('hud-root')!.appendChild(this.gestureHint);
+    document.getElementById('hud-root')!.appendChild(this.arHint);
 
     this.toastEl = document.getElementById('toast') as HTMLDivElement;
 
@@ -140,22 +119,11 @@ export class Hud {
 
   setMode(m: Mode): void {
     for (const k of Object.keys(this.modeButtons) as Mode[]) {
-      this.modeButtons[k].classList.toggle('active', k === m);
+      if (this.modeButtons[k]) {
+        this.modeButtons[k].classList.toggle('active', k === m);
+      }
     }
-    this.scanPanel.classList.toggle('active', m === 'scan');
-    this.gestureHint.classList.toggle('active', m === 'gestures');
-  }
-
-  setScanProgress(faceIndex: number, total: number, msg: string): void {
-    const prog = this.scanPanel.querySelector<HTMLDivElement>('#scan-progress')!;
-    prog.innerHTML = '';
-    for (let i = 0; i < total; i++) {
-      const span = document.createElement('span');
-      if (i < faceIndex) span.className = 'done';
-      else if (i === faceIndex) span.className = 'current';
-      prog.appendChild(span);
-    }
-    this.scanPanel.querySelector<HTMLElement>('#scan-msg')!.innerHTML = msg;
+    this.arHint.classList.toggle('active', m === 'ar');
   }
 
   toast(message: string, kind: 'info' | 'warn' | 'error' = 'info'): void {

--- a/src/hud/hud.css
+++ b/src/hud/hud.css
@@ -77,6 +77,13 @@ html, body {
   display: block;
 }
 
+#cv-layer.ar-mode {
+  right: 16px;
+  bottom: 16px;
+  width: 320px;
+  max-width: 40vw;
+}
+
 #cv-video {
   position: absolute;
   inset: 0;

--- a/src/render/OrbitCam.ts
+++ b/src/render/OrbitCam.ts
@@ -1,14 +1,16 @@
 import * as THREE from 'three';
-import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { TrackballControls } from 'three/examples/jsm/controls/TrackballControls.js';
 
-export function createOrbit(cam: THREE.Camera, dom: HTMLElement): OrbitControls {
-  const controls = new OrbitControls(cam, dom);
-  controls.enableDamping = true;
-  controls.dampingFactor = 0.12;
-  controls.enablePan = false;
+export function createOrbit(cam: THREE.Camera, dom: HTMLElement): TrackballControls {
+  const controls = new TrackballControls(cam, dom);
+  controls.rotateSpeed = 2.0;
   controls.zoomSpeed = 0.6;
-  controls.rotateSpeed = 0.8;
+  controls.panSpeed = 0.8;
+  controls.noPan = true;
+  controls.noZoom = false;
+  controls.dynamicDampingFactor = 0.12;
   controls.minDistance = 5;
   controls.maxDistance = 18;
+
   return controls;
 }

--- a/src/render/Scene.ts
+++ b/src/render/Scene.ts
@@ -51,6 +51,7 @@ function makeContactShadow(): THREE.Mesh {
     depthWrite: false,
   });
   const mesh = new THREE.Mesh(geo, mat);
+  mesh.name = 'contactShadow';
   mesh.rotation.x = -Math.PI / 2;
   mesh.position.y = -1.6;
   mesh.renderOrder = -1;

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ export type Move = `${Face}${Suffix}`;
 
 export type StickerColor = 'W' | 'Y' | 'R' | 'O' | 'G' | 'B';
 
-export type Mode = 'mouse' | 'gestures' | 'scan';
+export type Mode = 'mouse' | 'gestures' | 'scan' | 'ar';
 
 export const FACE_COLOR: Record<Face, StickerColor> = {
   U: 'W',


### PR DESCRIPTION
## Summary

- Add AR mode that uses webcam hand tracking to rotate the Rubik's cube
- Move right hand to discrete zones to rotate cube to specific positions
- Open palm gesture resets cube to front view
- Visual overlay shows detected hand skeleton

## Changes

- **Pinch detection**: New gesture type for future direct manipulation
- **Hand overlay**: Visualizes detected hands with skeleton and pinch indicator
- **Hand rotation**: Discrete zone-based cube rotation (left/right/up/down)
- **AR mode**: Replaces gesture and scan modes with simpler hand control
- **README**: Updated documentation for new AR controls

## Test plan

- [ ] Click AR mode button, allow camera access
- [ ] Move right hand left → cube rotates 90° left
- [ ] Move right hand right → cube rotates 90° right
- [ ] Move right hand up → cube tilts up
- [ ] Move right hand down → cube tilts down
- [ ] Open palm → cube returns to front view
- [ ] Hand skeleton overlay visible on camera preview