### PR TITLE
Add one-hand mode, constants extraction, and accessibility docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ lowercase = standard turn, uppercase = prime.
 | `l` / `L` | L / L' | `b` / `B` | B / B' |
 
 ### AR Mode
-Uses MediaPipe HandLandmarker to track your hand via webcam.
+Uses MediaPipe HandLandmarker to track your hands via webcam.
 
-**Cube rotation (right hand):**
+**Cube rotation (left hand - open palm):**
 
 | Hand position | Cube rotation |
 |---|---|
@@ -50,20 +50,32 @@ Uses MediaPipe HandLandmarker to track your hand via webcam.
 | Hand up | Cube tilts up |
 | Hand down | Cube tilts down |
 | Hand at center | Cube faces forward |
-| Open palm | Return to front view |
+| Palm facing in | Snap to nearest 90° |
+| Fist | Zoom out |
 
 The rotation is smooth and position-based (not velocity-based), making it
 easy to control.
 
-**Layer manipulation (pinch gesture):**
+**Layer manipulation (two-hand mode):**
 
-A 3×3 grid overlay appears on the camera feed. Pinch (thumb + index finger)
-on any cell and drag:
-- **Horizontal drag** → rotates that row (U, D layers)
-- **Vertical drag** → rotates that column (L, R layers)
+1. Left hand pinch → activates manipulation mode
+2. Right hand pinch on any grid cell and drag:
+   - **Horizontal drag** → rotates that row (U, D layers)
+   - **Vertical drag** → rotates that column (L, R layers)
 
-The grid provides clear visual feedback, highlighting the selected row or
-column as you drag.
+A 3×3 grid overlay appears with visual feedback, highlighting the selected
+row or column as you drag.
+
+**One-hand manipulation mode:**
+
+If no left hand is detected, you can use only your right hand:
+- Right hand pinch → both selects and manipulates the grid cell
+- Drag horizontally or vertically to rotate layers
+- Yellow indicator shows one-hand mode is active
+
+**Auto-solve gesture:**
+
+Hold both hands in fists for 1.5 seconds to trigger the automatic solver.
 
 ---
 

--- a/src/cv/HandOverlay.ts
+++ b/src/cv/HandOverlay.ts
@@ -15,6 +15,7 @@ const MODE_COLORS: Record<ModeColor, string> = {
   white: '#ffffff',
   blue: '#3b82f6',
   green: '#22c55e',
+  yellow: '#eab308',
   purple: '#a855f7',
 };
 

--- a/src/cv/LargeModeIndicator.ts
+++ b/src/cv/LargeModeIndicator.ts
@@ -4,12 +4,14 @@ const COLOR_MAP: Record<ModeColor, string> = {
   white: '#ffffff',
   blue: '#3b82f6',
   green: '#22c55e',
+  yellow: '#eab308',
   purple: '#a855f7',
 };
 
 const HINT_MAP: Record<string, string> = {
   ROTAR: 'Mueve la mano para girar',
   MANIPULAR: 'Arrastra para mover capa',
+  'UNA MANO': 'Arrastra con una mano',
   CARGANDO: 'Manten los punos...',
   RESOLVIENDO: 'Calculando solucion...',
 };

--- a/src/cv/ModeIndicator.ts
+++ b/src/cv/ModeIndicator.ts
@@ -4,6 +4,7 @@ const COLOR_MAP: Record<ModeColor, string> = {
   white: '#ffffff',
   blue: '#3b82f6',
   green: '#22c55e',
+  yellow: '#eab308',
   purple: '#a855f7',
 };
 

--- a/src/cv/gestures/DirectManipulation.ts
+++ b/src/cv/gestures/DirectManipulation.ts
@@ -3,6 +3,17 @@ import type { Face, Move } from '../../types';
 import type { CubeView, Cubie } from '../../cube/CubeView';
 import type { MoveEngine } from '../../cube/MoveEngine';
 import type { HandShape, Handedness, Landmark } from './types';
+import {
+  DIRECT_DRAG_THRESHOLD,
+  ROTATION_SENSITIVITY,
+  FACE_NORMAL_THRESHOLD,
+  AXIS_MATCH_THRESHOLD,
+  DIRECT_SNAP_DURATION,
+  SINGLE_TURN_THRESHOLD,
+  DOUBLE_TURN_THRESHOLD,
+  LANDMARK_THUMB_TIP,
+  LANDMARK_INDEX_TIP,
+} from './constants';
 
 type GrabPhase = 'IDLE' | 'PINCHING' | 'DRAGGING' | 'RELEASING';
 
@@ -33,9 +44,6 @@ const AXIS_TO_FACES: [THREE.Vector3, Face, Face][] = [
   [new THREE.Vector3(0, 1, 0), 'U', 'D'],
   [new THREE.Vector3(0, 0, 1), 'F', 'B'],
 ];
-
-const DRAG_THRESHOLD = 0.03;
-const ROTATION_SENSITIVITY = 3.5;
 
 export class DirectManipulation {
   private raycaster = new THREE.Raycaster();
@@ -94,8 +102,8 @@ export class DirectManipulation {
   }
 
   private getPinchPoint(landmarks: Landmark[]): Landmark {
-    const thumb = landmarks[4];
-    const index = landmarks[8];
+    const thumb = landmarks[LANDMARK_THUMB_TIP];
+    const index = landmarks[LANDMARK_INDEX_TIP];
     return {
       x: (thumb.x + index.x) / 2,
       y: (thumb.y + index.y) / 2,
@@ -126,7 +134,7 @@ export class DirectManipulation {
     const ndc = this.toNDC(pinchPoint);
     const delta = ndc.clone().sub(this.grabState.startNDC);
 
-    if (delta.length() < DRAG_THRESHOLD) return;
+    if (delta.length() < DIRECT_DRAG_THRESHOLD) return;
 
     // Determine layer based on hit and drag direction
     const hit = this.raycastToCube(this.grabState.startNDC.x, this.grabState.startNDC.y);
@@ -181,7 +189,7 @@ export class DirectManipulation {
       }
     }
 
-    if (!hitFace || maxDot < 0.8) return null;
+    if (!hitFace || maxDot < FACE_NORMAL_THRESHOLD) return null;
 
     // Get the cubie's position
     let cubie: Cubie | null = null;
@@ -224,7 +232,7 @@ export class DirectManipulation {
       }
     }
 
-    if (bestAxisIdx < 0 || bestDot < 0.5) return null;
+    if (bestAxisIdx < 0 || bestDot < AXIS_MATCH_THRESHOLD) return null;
 
     const [standardAxis, posFace, negFace] = AXIS_TO_FACES[bestAxisIdx];
     const sign = rotationAxis.dot(standardAxis) > 0 ? 1 : -1;
@@ -310,10 +318,10 @@ export class DirectManipulation {
     let targetAngle: number;
     let move: Move | null = null;
 
-    if (absAngle < Math.PI / 4) {
+    if (absAngle < SINGLE_TURN_THRESHOLD) {
       // Less than 45 degrees - cancel
       targetAngle = 0;
-    } else if (absAngle < (3 * Math.PI) / 4) {
+    } else if (absAngle < DOUBLE_TURN_THRESHOLD) {
       // 45-135 degrees - single turn
       targetAngle = angle > 0 ? Math.PI / 2 : -Math.PI / 2;
       const suffix = angle > 0 ? "'" : '';
@@ -355,7 +363,7 @@ export class DirectManipulation {
     _cubies: Cubie[],
   ): Promise<void> {
     return new Promise((resolve) => {
-      const duration = 150;
+      const duration = DIRECT_SNAP_DURATION;
       const start = performance.now();
 
       const tick = () => {

--- a/src/cv/gestures/GestureClassifier.ts
+++ b/src/cv/gestures/GestureClassifier.ts
@@ -1,11 +1,51 @@
 import type { HandLandmarkerResult } from '@mediapipe/tasks-vision';
 import type { GestureFrame, HandShape, Handedness, Landmark } from './types';
+import {
+  PINCH_THRESHOLD,
+  FINGER_EXTENSION_RATIO,
+  THUMB_UP_THRESHOLD,
+  THUMB_DOWN_THRESHOLD,
+  LANDMARK_WRIST,
+  LANDMARK_THUMB_TIP,
+  LANDMARK_THUMB_PIP,
+  LANDMARK_THUMB_MCP,
+  LANDMARK_INDEX_TIP,
+  LANDMARK_INDEX_PIP,
+  LANDMARK_INDEX_MCP,
+  LANDMARK_MIDDLE_TIP,
+  LANDMARK_MIDDLE_PIP,
+  LANDMARK_MIDDLE_MCP,
+  LANDMARK_RING_TIP,
+  LANDMARK_RING_PIP,
+  LANDMARK_RING_MCP,
+  LANDMARK_PINKY_TIP,
+  LANDMARK_PINKY_PIP,
+  LANDMARK_PINKY_MCP,
+} from './constants';
 
-const FINGER_TIPS = [4, 8, 12, 16, 20];
-const FINGER_PIPS = [3, 6, 10, 14, 18];
-const FINGER_MCPS = [2, 5, 9, 13, 17];
-const WRIST = 0;
-const MIDDLE_MCP = 9;
+const FINGER_TIPS = [
+  LANDMARK_THUMB_TIP,
+  LANDMARK_INDEX_TIP,
+  LANDMARK_MIDDLE_TIP,
+  LANDMARK_RING_TIP,
+  LANDMARK_PINKY_TIP,
+];
+const FINGER_PIPS = [
+  LANDMARK_THUMB_PIP,
+  LANDMARK_INDEX_PIP,
+  LANDMARK_MIDDLE_PIP,
+  LANDMARK_RING_PIP,
+  LANDMARK_PINKY_PIP,
+];
+const FINGER_MCPS = [
+  LANDMARK_THUMB_MCP,
+  LANDMARK_INDEX_MCP,
+  LANDMARK_MIDDLE_MCP,
+  LANDMARK_RING_MCP,
+  LANDMARK_PINKY_MCP,
+];
+const WRIST = LANDMARK_WRIST;
+const MIDDLE_MCP = LANDMARK_MIDDLE_MCP;
 
 function dist(a: Landmark, b: Landmark): number {
   const dx = a.x - b.x;
@@ -22,17 +62,17 @@ function isFingerExtended(landmarks: Landmark[], finger: number): boolean {
   const tipDist = dist(tip, wrist);
   const pipDist = dist(pip, wrist);
   const mcpDist = dist(mcp, wrist);
-  return tipDist > pipDist && pipDist > mcpDist * 0.95;
+  return tipDist > pipDist && pipDist > mcpDist * FINGER_EXTENSION_RATIO;
 }
 
 function isPinching(landmarks: Landmark[]): boolean {
-  const thumbTip = landmarks[4];
-  const indexTip = landmarks[8];
+  const thumbTip = landmarks[LANDMARK_THUMB_TIP];
+  const indexTip = landmarks[LANDMARK_INDEX_TIP];
   const wrist = landmarks[WRIST];
   const middleMcp = landmarks[MIDDLE_MCP];
   const handSize = dist(wrist, middleMcp);
   const pinchDist = dist(thumbTip, indexTip) / handSize;
-  return pinchDist < 0.18;
+  return pinchDist < PINCH_THRESHOLD;
 }
 
 function classify(landmarks: Landmark[], hand: Handedness): HandShape {
@@ -45,8 +85,8 @@ function classify(landmarks: Landmark[], hand: Handedness): HandShape {
 
   const ext = [0, 1, 2, 3, 4].map((f) => isFingerExtended(landmarks, f));
   const [thumbExt, indexExt, middleExt, ringExt, pinkyExt] = ext;
-  const indexTip = landmarks[8];
-  const indexMcp = landmarks[5];
+  const indexTip = landmarks[LANDMARK_INDEX_TIP];
+  const indexMcp = landmarks[LANDMARK_INDEX_MCP];
 
   const fingersExtCount = (indexExt ? 1 : 0) + (middleExt ? 1 : 0) + (ringExt ? 1 : 0) + (pinkyExt ? 1 : 0);
 
@@ -58,8 +98,8 @@ function classify(landmarks: Landmark[], hand: Handedness): HandShape {
   // Open palm: 4+ fingers extended
   if (fingersExtCount >= 3 && thumbExt) {
     // Determine palm orientation: cross product of (indexMcp - wrist) and (pinky_mcp - wrist)
-    const v1 = sub(landmarks[5], wrist);
-    const v2 = sub(landmarks[17], wrist);
+    const v1 = sub(landmarks[LANDMARK_INDEX_MCP], wrist);
+    const v2 = sub(landmarks[LANDMARK_PINKY_MCP], wrist);
     const cross = crossZ(v1, v2);
     // For Right hand, palm-towards-camera means the palm faces +Z (out of screen).
     // Image coords: x grows right, y grows down. Cross sign indicates orientation.
@@ -69,9 +109,9 @@ function classify(landmarks: Landmark[], hand: Handedness): HandShape {
 
   // Thumb up/down: thumb extended, others curled
   if (thumbExt && fingersExtCount === 0) {
-    const thumbTip = landmarks[4];
-    if (thumbTip.y < wrist.y - 0.08) return { hand, shape: 'thumbUp', wrist };
-    if (thumbTip.y > wrist.y + 0.08) return { hand, shape: 'thumbDown', wrist };
+    const thumbTip = landmarks[LANDMARK_THUMB_TIP];
+    if (thumbTip.y < wrist.y - THUMB_UP_THRESHOLD) return { hand, shape: 'thumbUp', wrist };
+    if (thumbTip.y > wrist.y + THUMB_DOWN_THRESHOLD) return { hand, shape: 'thumbDown', wrist };
   }
 
   // Pointing: index extended, others curled

--- a/src/cv/gestures/GridManipulation.ts
+++ b/src/cv/gestures/GridManipulation.ts
@@ -2,6 +2,13 @@ import type { Face, Move } from '../../types';
 import type { CubeView } from '../../cube/CubeView';
 import type { MoveEngine } from '../../cube/MoveEngine';
 import type { HandShape, Handedness, Landmark } from './types';
+import {
+  DRAG_THRESHOLD,
+  GRID_PADDING,
+  GRID_SIZE,
+  THUMB_TIP,
+  INDEX_TIP,
+} from './constants';
 
 type Phase = 'IDLE' | 'PINCHING' | 'DRAGGING';
 
@@ -39,8 +46,6 @@ const COL_MOVES: Record<number, { down: Move; up: Move }> = {
 // For highlighting (only outer faces)
 const ROW_TO_FACE: Record<number, Face | null> = { 0: 'U', 1: null, 2: 'D' };
 const COL_TO_FACE: Record<number, Face | null> = { 0: 'L', 1: null, 2: 'R' };
-
-const DRAG_THRESHOLD = 0.04;
 
 export class GridManipulation {
   private phase: Phase = 'IDLE';
@@ -103,8 +108,8 @@ export class GridManipulation {
   }
 
   private getPinchPoint(landmarks: Landmark[]): { x: number; y: number } {
-    const thumb = landmarks[4];
-    const index = landmarks[8];
+    const thumb = landmarks[THUMB_TIP];
+    const index = landmarks[INDEX_TIP];
     return {
       x: (thumb.x + index.x) / 2,
       y: (thumb.y + index.y) / 2,
@@ -115,17 +120,16 @@ export class GridManipulation {
     // Mirror x for flipped video
     const mirroredX = 1 - x;
 
-    // Grid occupies center area with padding (8% on each side = 84% area)
-    const padding = 0.08;
-    const gridSize = 1 - 2 * padding;
+    // Grid occupies center area with padding
+    const gridSize = 1 - 2 * GRID_PADDING;
 
-    const relX = (mirroredX - padding) / gridSize;
-    const relY = (y - padding) / gridSize;
+    const relX = (mirroredX - GRID_PADDING) / gridSize;
+    const relY = (y - GRID_PADDING) / gridSize;
 
     if (relX < 0 || relX > 1 || relY < 0 || relY > 1) return null;
 
-    const col = Math.floor(relX * 3);
-    const row = Math.floor(relY * 3);
+    const col = Math.floor(relX * GRID_SIZE);
+    const row = Math.floor(relY * GRID_SIZE);
 
     return {
       row: Math.min(2, Math.max(0, row)),

--- a/src/cv/gestures/HandRotation.ts
+++ b/src/cv/gestures/HandRotation.ts
@@ -1,18 +1,21 @@
 import * as THREE from 'three';
 import type { CubeView } from '../../cube/CubeView';
 import type { Landmark, Handedness, HandShape } from './types';
-
-// Adaptive smoothing
-const SMOOTHING_MIN = 0.08; // Fast when far from target
-const SMOOTHING_MAX = 0.25; // Slow when near target
-
-// Swipe detection
-const SWIPE_THRESHOLD = 0.12;
-const SWIPE_TIME_MS = 300;
-
-// Zoom limits
-const MAX_ZOOM = 12;
-const DEFAULT_ZOOM = 5.4;
+import {
+  SMOOTHING_MIN,
+  SMOOTHING_MAX,
+  SWIPE_THRESHOLD,
+  SWIPE_TIME_MS,
+  MAX_ZOOM,
+  DEFAULT_ZOOM,
+  ZOOM_SPEED,
+  ZOOM_OUT_SPEED,
+  MAX_ROTATION_Y,
+  MAX_ROTATION_X,
+  SWIPE_ROTATION_Y,
+  SWIPE_ROTATION_X,
+  SNAP_ANIMATION_DURATION,
+} from './constants';
 
 export class HandRotation {
   private targetY = 0;
@@ -63,17 +66,17 @@ export class HandRotation {
     // Check for zoom gesture (all fingers together = pinch closed)
     if (leftShape?.shape === 'fist') {
       // Zoom out when fist
-      this.targetZoom = Math.min(MAX_ZOOM, this.targetZoom + 0.15);
+      this.targetZoom = Math.min(MAX_ZOOM, this.targetZoom + ZOOM_OUT_SPEED);
     } else if (leftShape?.shape === 'palmOut' || leftShape?.shape === 'palmIn') {
       // Zoom in when palm open (gradually return to default)
       if (this.targetZoom > DEFAULT_ZOOM) {
-        this.targetZoom = Math.max(DEFAULT_ZOOM, this.targetZoom - 0.1);
+        this.targetZoom = Math.max(DEFAULT_ZOOM, this.targetZoom - ZOOM_SPEED);
       }
     }
 
     // Apply zoom smoothly
     if (this.camera) {
-      this.currentZoom += (this.targetZoom - this.currentZoom) * 0.1;
+      this.currentZoom += (this.targetZoom - this.currentZoom) * ZOOM_SPEED;
       const dir = this.camera.position.clone().normalize();
       this.camera.position.copy(dir.multiplyScalar(this.currentZoom));
     }
@@ -104,11 +107,11 @@ export class HandRotation {
         if (swipeTime < SWIPE_TIME_MS) {
           if (Math.abs(swipeDx) > SWIPE_THRESHOLD && Math.abs(swipeDx) > Math.abs(swipeDy)) {
             // Horizontal swipe - add momentum to Y rotation
-            this.targetY += swipeDx > 0 ? Math.PI / 2 : -Math.PI / 2;
+            this.targetY += swipeDx > 0 ? SWIPE_ROTATION_Y : -SWIPE_ROTATION_Y;
             this.swipeStartPos = null;
           } else if (Math.abs(swipeDy) > SWIPE_THRESHOLD && Math.abs(swipeDy) > Math.abs(swipeDx)) {
             // Vertical swipe - add momentum to X rotation
-            this.targetX += swipeDy > 0 ? Math.PI / 4 : -Math.PI / 4;
+            this.targetX += swipeDy > 0 ? SWIPE_ROTATION_X : -SWIPE_ROTATION_X;
             this.targetX = Math.max(-Math.PI / 2, Math.min(Math.PI / 2, this.targetX));
             this.swipeStartPos = null;
           }
@@ -122,8 +125,8 @@ export class HandRotation {
         const centerOffsetX = (x - 0.5) * 2; // -1 to 1
         const centerOffsetY = (y - 0.5) * 2; // -1 to 1
 
-        this.targetY = centerOffsetX * Math.PI * 0.6; // Max ±108 degrees
-        this.targetX = centerOffsetY * Math.PI * 0.25; // Max ±45 degrees
+        this.targetY = centerOffsetX * MAX_ROTATION_Y;
+        this.targetX = centerOffsetY * MAX_ROTATION_X;
       }
 
       this.lastWristPos = { x, y };
@@ -153,7 +156,7 @@ export class HandRotation {
     const snappedY = Math.round(this.currentY / (Math.PI / 2)) * (Math.PI / 2);
     const snappedX = Math.round(this.currentX / (Math.PI / 2)) * (Math.PI / 2);
 
-    this.animateSnap(this.currentY, snappedY, this.currentX, snappedX, 200);
+    this.animateSnap(this.currentY, snappedY, this.currentX, snappedX, SNAP_ANIMATION_DURATION);
   }
 
   private animateSnap(fromY: number, toY: number, fromX: number, toX: number, duration: number): void {

--- a/src/cv/gestures/TwoHandController.ts
+++ b/src/cv/gestures/TwoHandController.ts
@@ -7,12 +7,11 @@ import type { CubeModel } from '../../cube/CubeModel';
 import type { Move } from '../../types';
 import { expandHalfTurns } from '../../cube/Notation';
 import { bus } from '../../app/events';
+import { SOLVER_CHARGE_TIME } from './constants';
 
-export type ControllerState = 'IDLE' | 'ROTATION' | 'MANIPULATION' | 'SOLVER_CHARGING' | 'SOLVING';
+export type ControllerState = 'IDLE' | 'ROTATION' | 'MANIPULATION' | 'ONE_HAND_MANIPULATION' | 'SOLVER_CHARGING' | 'SOLVING';
 
-export type ModeColor = 'white' | 'blue' | 'green' | 'purple';
-
-const SOLVER_CHARGE_TIME = 1500; // 1.5 seconds
+export type ModeColor = 'white' | 'blue' | 'green' | 'yellow' | 'purple';
 
 export class TwoHandController {
   private state: ControllerState = 'IDLE';
@@ -50,6 +49,10 @@ export class TwoHandController {
         this.handleManipulation(leftHand, rightHand, bothFists, landmarks);
         break;
 
+      case 'ONE_HAND_MANIPULATION':
+        this.handleOneHandManipulation(leftHand, rightHand, bothFists, landmarks);
+        break;
+
       case 'SOLVER_CHARGING':
         this.handleSolverCharging(bothFists);
         break;
@@ -70,7 +73,7 @@ export class TwoHandController {
     bothFists: boolean,
     landmarks: Map<Handedness, Landmark[]>,
   ): void {
-    // Priority: solver > manipulation > rotation
+    // Priority: solver > manipulation > one-hand manipulation > rotation
     if (bothFists) {
       this.state = 'SOLVER_CHARGING';
       this.solverChargeStart = performance.now();
@@ -79,8 +82,17 @@ export class TwoHandController {
       return;
     }
 
+    // Two-hand manipulation (left pinch activates, right manipulates)
     if (leftHand?.shape === 'pinch') {
       this.state = 'MANIPULATION';
+      this.handRotation.setEnabled(false);
+      this.gridManipulation.setActive(true);
+      return;
+    }
+
+    // One-hand manipulation (only right hand pinch, no left hand)
+    if (!leftHand && rightHand?.shape === 'pinch') {
+      this.state = 'ONE_HAND_MANIPULATION';
       this.handRotation.setEnabled(false);
       this.gridManipulation.setActive(true);
       return;
@@ -165,6 +177,48 @@ export class TwoHandController {
     this.gridManipulation.processFrame(rightOnlyHands, landmarks);
   }
 
+  private handleOneHandManipulation(
+    leftHand: HandShape | undefined,
+    rightHand: HandShape | undefined,
+    bothFists: boolean,
+    landmarks: Map<Handedness, Landmark[]>,
+  ): void {
+    // Check for mode transitions
+    if (bothFists) {
+      this.state = 'SOLVER_CHARGING';
+      this.solverChargeStart = performance.now();
+      this.gridManipulation.setActive(false);
+      return;
+    }
+
+    // If left hand appears, could transition to two-hand manipulation or rotation
+    if (leftHand) {
+      if (leftHand.shape === 'pinch') {
+        this.state = 'MANIPULATION';
+        // Keep grid manipulation active
+        return;
+      }
+      if (leftHand.shape === 'palmOut' || leftHand.shape === 'palmIn') {
+        this.state = 'ROTATION';
+        this.handRotation.setEnabled(true);
+        this.gridManipulation.setActive(false);
+        this.handRotation.processFrame(landmarks, [leftHand, rightHand].filter(Boolean) as HandShape[]);
+        return;
+      }
+    }
+
+    // Right hand must maintain pinch to stay in one-hand manipulation mode
+    if (rightHand?.shape !== 'pinch') {
+      this.state = 'IDLE';
+      this.gridManipulation.setActive(false);
+      return;
+    }
+
+    // Process right hand for both selection and manipulation
+    const rightHandArray = rightHand ? [rightHand] : [];
+    this.gridManipulation.processFrame(rightHandArray, landmarks);
+  }
+
   private handleSolverCharging(bothFists: boolean): void {
     if (!bothFists) {
       // Cancelled - return to idle
@@ -227,6 +281,8 @@ export class TwoHandController {
         return 'blue';
       case 'MANIPULATION':
         return 'green';
+      case 'ONE_HAND_MANIPULATION':
+        return 'yellow';
       case 'SOLVER_CHARGING':
       case 'SOLVING':
         return 'purple';
@@ -241,6 +297,8 @@ export class TwoHandController {
         return 'ROTAR';
       case 'MANIPULATION':
         return 'MANIPULAR';
+      case 'ONE_HAND_MANIPULATION':
+        return 'UNA MANO';
       case 'SOLVER_CHARGING':
         return 'CARGANDO...';
       case 'SOLVING':

--- a/src/cv/gestures/constants.ts
+++ b/src/cv/gestures/constants.ts
@@ -1,0 +1,131 @@
+/**
+ * Gesture system constants
+ *
+ * Centralized configuration for gesture recognition and manipulation thresholds.
+ */
+
+// ============================================================================
+// GridManipulation constants
+// ============================================================================
+
+/** Minimum drag distance to initiate a drag gesture (in normalized coordinates 0-1) */
+export const DRAG_THRESHOLD = 0.04;
+
+/** Grid padding on each side as a ratio of the screen (8% = 0.08) */
+export const GRID_PADDING = 0.08;
+
+/** Number of grid rows/columns */
+export const GRID_SIZE = 3;
+
+/** Pinch point calculation - landmark indices */
+export const THUMB_TIP = 4;
+export const INDEX_TIP = 8;
+
+// ============================================================================
+// HandRotation constants
+// ============================================================================
+
+/** Minimum smoothing factor for hand rotation (fast when far from target) */
+export const SMOOTHING_MIN = 0.08;
+
+/** Maximum smoothing factor for hand rotation (slow when near target) */
+export const SMOOTHING_MAX = 0.25;
+
+/** Swipe detection threshold (in normalized coordinates 0-1) */
+export const SWIPE_THRESHOLD = 0.12;
+
+/** Maximum time window for swipe gesture detection (milliseconds) */
+export const SWIPE_TIME_MS = 300;
+
+/** Maximum zoom distance */
+export const MAX_ZOOM = 12;
+
+/** Default camera zoom distance */
+export const DEFAULT_ZOOM = 5.4;
+
+/** Zoom speed adjustment factor */
+export const ZOOM_SPEED = 0.1;
+
+/** Zoom-out speed when fist gesture is detected */
+export const ZOOM_OUT_SPEED = 0.15;
+
+/** Maximum horizontal rotation offset (in radians, ±108 degrees) */
+export const MAX_ROTATION_Y = Math.PI * 0.6;
+
+/** Maximum vertical rotation offset (in radians, ±45 degrees) */
+export const MAX_ROTATION_X = Math.PI * 0.25;
+
+/** Horizontal swipe adds 90 degrees of rotation */
+export const SWIPE_ROTATION_Y = Math.PI / 2;
+
+/** Vertical swipe adds 45 degrees of rotation */
+export const SWIPE_ROTATION_X = Math.PI / 4;
+
+/** Duration for snap-to-90 animation (milliseconds) */
+export const SNAP_ANIMATION_DURATION = 200;
+
+// ============================================================================
+// TwoHandController constants
+// ============================================================================
+
+/** Time to hold both fists to trigger the solver (milliseconds) */
+export const SOLVER_CHARGE_TIME = 1500;
+
+// ============================================================================
+// GestureClassifier constants
+// ============================================================================
+
+/** Pinch detection threshold (ratio of pinch distance to hand size) */
+export const PINCH_THRESHOLD = 0.18;
+
+/** Finger extension check - PIP must be at least 95% of MCP distance from wrist */
+export const FINGER_EXTENSION_RATIO = 0.95;
+
+/** Minimum Y offset for thumb-up gesture (normalized coordinates) */
+export const THUMB_UP_THRESHOLD = 0.08;
+
+/** Minimum Y offset for thumb-down gesture (normalized coordinates) */
+export const THUMB_DOWN_THRESHOLD = 0.08;
+
+/** MediaPipe landmark indices */
+export const LANDMARK_WRIST = 0;
+export const LANDMARK_THUMB_TIP = 4;
+export const LANDMARK_THUMB_PIP = 3;
+export const LANDMARK_THUMB_MCP = 2;
+export const LANDMARK_INDEX_TIP = 8;
+export const LANDMARK_INDEX_PIP = 6;
+export const LANDMARK_INDEX_MCP = 5;
+export const LANDMARK_MIDDLE_TIP = 12;
+export const LANDMARK_MIDDLE_PIP = 10;
+export const LANDMARK_MIDDLE_MCP = 9;
+export const LANDMARK_RING_TIP = 16;
+export const LANDMARK_RING_PIP = 14;
+export const LANDMARK_RING_MCP = 13;
+export const LANDMARK_PINKY_TIP = 20;
+export const LANDMARK_PINKY_PIP = 18;
+export const LANDMARK_PINKY_MCP = 17;
+
+// ============================================================================
+// DirectManipulation constants
+// ============================================================================
+
+/** Minimum drag distance to start direct manipulation (in NDC coordinates) */
+export const DIRECT_DRAG_THRESHOLD = 0.03;
+
+/** Rotation sensitivity multiplier for direct manipulation */
+export const ROTATION_SENSITIVITY = 3.5;
+
+/** Minimum dot product for face normal matching */
+export const FACE_NORMAL_THRESHOLD = 0.8;
+
+/** Minimum dot product for axis matching */
+export const AXIS_MATCH_THRESHOLD = 0.5;
+
+/** Snap animation duration for direct manipulation (milliseconds) */
+export const DIRECT_SNAP_DURATION = 150;
+
+/** Rotation threshold for single turn (radians, 45 degrees) */
+export const SINGLE_TURN_THRESHOLD = Math.PI / 4;
+
+/** Rotation threshold for double turn (radians, 135 degrees) */
+export const DOUBLE_TURN_THRESHOLD = (3 * Math.PI) / 4;


### PR DESCRIPTION
## Summary
- Extract magic numbers to centralized constants file (fixes #22)
- Add one-hand manipulation mode (fixes #20)
- Document AR controls in README (fixes #21)

## Changes

### Constants Extraction (#22)
Created `src/cv/gestures/constants.ts` with all magic numbers organized by module:
- GridManipulation constants (drag thresholds, grid sizing)
- HandRotation constants (smoothing, swipe detection, rotation limits)
- TwoHandController constants (solver charge time)
- GestureClassifier constants (pinch threshold, landmark indices)
- DirectManipulation constants (drag threshold, rotation sensitivity)

All gesture files now import from this central location.

### One-Hand Mode (#20)
- Added `ONE_HAND_MANIPULATION` controller state
- When only RIGHT hand is detected with pinch (no left hand), enters one-hand mode
- Right hand can both select grid cell AND drag to rotate layers
- Yellow visual indicator shows "UNA MANO" mode
- Updated ModeIndicator, LargeModeIndicator, and HandOverlay with yellow color

### Accessibility Documentation (#21)
- Expanded AR Mode section in README with comprehensive gesture documentation
- Documented all control modes (rotation, two-hand, one-hand, auto-solve)
- Keyboard controls were already implemented (r/u/f/d/l/b)

## Test plan
- [ ] Verify constants are imported correctly (build passes)
- [ ] Test one-hand mode: pinch with right hand only, drag to rotate layers
- [ ] Verify yellow indicator appears in one-hand mode
- [ ] Check README documentation is accurate

## Related Issues
Closes #20, closes #21, closes #22