### PR TITLE
fix: add solver timeout handling

### DIFF
--- a/src/solver/Solver.ts
+++ b/src/solver/Solver.ts
@@ -1,29 +1,62 @@
 import type { Move } from '../types';
 import { bus } from '../app/events';
 
+const DEFAULT_SOLVER_TIMEOUT_MS = 30_000;
+const SOLVER_TIMEOUT_MESSAGE = 'El solucionador tardó demasiado. Intenta reiniciar el cubo.';
+const SOLVER_WORKER_ERROR_MESSAGE = 'Error del solucionador';
+
 export class Solver {
   private worker: Worker;
   private ready = false;
   private readyPromise: Promise<void>;
 
   constructor() {
-    this.worker = new Worker(new URL('./solver.worker.ts', import.meta.url), { type: 'module' });
-    this.readyPromise = new Promise((resolve, reject) => {
+    this.worker = this.createWorker();
+    this.readyPromise = this.initWorker();
+  }
+
+  private createWorker(): Worker {
+    return new Worker(new URL('./solver.worker.ts', import.meta.url), { type: 'module' });
+  }
+
+  private initWorker(): Promise<void> {
+    this.ready = false;
+    const worker = this.worker;
+
+    return new Promise((resolve, reject) => {
+      const cleanup = () => {
+        worker.removeEventListener('message', onMsg);
+        worker.removeEventListener('error', onError);
+      };
       const onMsg = (e: MessageEvent) => {
         const data = e.data;
         if (data.type === 'ready') {
           this.ready = true;
-          this.worker.removeEventListener('message', onMsg);
+          cleanup();
           bus.emit('solver:ready', undefined);
           resolve();
         } else if (data.type === 'error') {
-          this.worker.removeEventListener('message', onMsg);
+          cleanup();
           reject(new Error(data.message));
         }
       };
-      this.worker.addEventListener('message', onMsg);
-      this.worker.postMessage({ type: 'init' });
+      const onError = (event: ErrorEvent) => {
+        cleanup();
+        reject(new Error(event.message || SOLVER_WORKER_ERROR_MESSAGE));
+      };
+
+      worker.addEventListener('message', onMsg);
+      worker.addEventListener('error', onError);
+      worker.postMessage({ type: 'init' });
     });
+  }
+
+  private restartWorker(failedWorker: Worker): void {
+    failedWorker.terminate();
+    if (this.worker === failedWorker) {
+      this.worker = this.createWorker();
+      this.readyPromise = this.initWorker();
+    }
   }
 
   whenReady(): Promise<void> {
@@ -34,25 +67,60 @@ export class Solver {
     return this.ready;
   }
 
-  async solve(facelets: string): Promise<Move[]> {
+  async solve(facelets: string, timeoutMs = DEFAULT_SOLVER_TIMEOUT_MS): Promise<Move[]> {
     await this.readyPromise;
     bus.emit('solver:solving', undefined);
+    const worker = this.worker;
+
     return new Promise((resolve, reject) => {
+      let settled = false;
+      let timeoutId: number | undefined;
+
+      const cleanup = () => {
+        if (timeoutId !== undefined) {
+          window.clearTimeout(timeoutId);
+        }
+        worker.removeEventListener('message', onMsg);
+        worker.removeEventListener('error', onError);
+      };
+
+      const fail = (message: string, restartWorker: boolean) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        bus.emit('solver:error', { message });
+        if (restartWorker) {
+          this.restartWorker(worker);
+        }
+        reject(new Error(message));
+      };
+
       const onMsg = (e: MessageEvent) => {
         const data = e.data;
         if (data.type === 'solution') {
-          this.worker.removeEventListener('message', onMsg);
+          if (settled) return;
+          settled = true;
+          cleanup();
           const moves = data.moves as Move[];
           bus.emit('solver:solution', { moves });
           resolve(moves);
         } else if (data.type === 'error') {
-          this.worker.removeEventListener('message', onMsg);
-          bus.emit('solver:error', { message: data.message });
-          reject(new Error(data.message));
+          fail(data.message, false);
         }
       };
-      this.worker.addEventListener('message', onMsg);
-      this.worker.postMessage({ type: 'solve', facelets });
+
+      const onError = (event: ErrorEvent) => {
+        console.error('[Solver] Worker error:', event.error ?? event.message);
+        fail(event.message || SOLVER_WORKER_ERROR_MESSAGE, true);
+      };
+
+      timeoutId = window.setTimeout(() => {
+        fail(SOLVER_TIMEOUT_MESSAGE, true);
+      }, timeoutMs);
+
+      worker.addEventListener('message', onMsg);
+      worker.addEventListener('error', onError);
+      worker.postMessage({ type: 'solve', facelets });
     });
   }
 }


### PR DESCRIPTION
## Summary
- add a 30s timeout around solver worker requests so solve promises cannot hang forever
- clean up message/error listeners on every completion path
- handle worker error events, surface a solver error, and restart the worker after timeouts or worker failures

## Test plan
- npm run build

Fixes #38
